### PR TITLE
Fix for e.g. "Deadly(0)"

### DIFF
--- a/services/RulesService.ts
+++ b/services/RulesService.ts
@@ -3,7 +3,7 @@ import { ISpecialRule } from "../data/interfaces";
 export default class RulesService {
     public static displayName(rule: ISpecialRule) {
         return rule.name
-            + (rule.rating ? `(${(rule.name === "Defense" || rule.modify ? "+" : "") + rule.rating})` : "")
+            + ((rule.rating != null) ? `(${(rule.name === "Defense" || rule.modify ? "+" : "") + rule.rating})` : "")
             + (rule.condition ? ` ${rule.condition}` : "");
     }
 }

--- a/views/components/RuleList.tsx
+++ b/views/components/RuleList.tsx
@@ -34,13 +34,15 @@ export default function RuleList({ specialRules }: { specialRules: ISpecialRule[
           // Sum all occurrences
           : group.reduce((total, next) => next.rating ? total + parseInt(next.rating) : total, 0);
 
+          console.log(rule)
         const ruleDefinition = ruleDefinitions
           .filter(r => /(.+?)(?:\(|$)/.exec(r.name)[0] === rule.name)[0];
-
         return (
           <Fragment key={index}>
             {index > 0 ? <span className="mr-1">, </span> : null}
-            <RuleItem label={RulesService.displayName({ ...rule, rating: rating > 0 ? rating.toString() : null })} description={ruleDefinition?.description || ""} />
+            <RuleItem 
+              label={RulesService.displayName({ ...rule, rating: rule.rating ? rating.toString() : null })}
+              description={ruleDefinition?.description || ""} />
           </Fragment>
         );
       })}


### PR DESCRIPTION
Falsy ratings (i.e. ratings of 0) were not being displayed as real ratings. They now are.

![Screenshot 2021-11-04 075554](https://user-images.githubusercontent.com/23005404/140277342-801e5972-2954-4e44-863f-f9a1bba5d14c.png)