### PR TITLE
Fix #177 - Show replaced equipment

### DIFF
--- a/views/upgrades/UpgradeItem.tsx
+++ b/views/upgrades/UpgradeItem.tsx
@@ -88,12 +88,12 @@ export default function UpgradeItem({ selectedUnit, upgrade, option }: { selecte
             const count = group.length
 
             return <UpgradeItemDisplay key={i} eqp={e} count={count} />;
-          }) : <span style={{ color: "#000000" }}>{
+          }) : <span className="is-size-6" style={{ color: "#888888" }}>{
             upgrade.replaceWhat && upgrade.type == "replace" ? 
-              <>Keep {upgrade.replaceWhat.map((e, i) => {
+              <><span className="is-size-6" style={{ color: "#61526c" }}>{upgrade.replaceWhat.map((e, i) => {
                 let w = EquipmentService.findLast(selectedUnit.equipment, e)
-                return `${w ? EquipmentService.formatString(w) : e} `
-              })}</>
+                return `${i > 0 ? ", " : ""}${w ? EquipmentService.formatString(w) : e}`
+              })}</span> (default)</>
             : "None"}</span>
         }
       </div>

--- a/views/upgrades/UpgradeItem.tsx
+++ b/views/upgrades/UpgradeItem.tsx
@@ -88,7 +88,11 @@ export default function UpgradeItem({ selectedUnit, upgrade, option }: { selecte
             const count = group.length
 
             return <UpgradeItemDisplay key={i} eqp={e} count={count} />;
-          }) : <span style={{ color: "#000000" }}>None</span>
+          }) : upgrade.replaceWhat && upgrade.type == "replace" ? 
+          upgrade.replaceWhat.map((e, i) => {
+            return <UpgradeItemDisplay key={`d${i}`} eqp={{...EquipmentService.findLast(selectedUnit.equipment, e), type:"ArmyBookWeapon"}} count={1} />
+          })
+          : <span style={{ color: "#000000" }}>None</span>
         }
       </div>
       <div>

--- a/views/upgrades/UpgradeItem.tsx
+++ b/views/upgrades/UpgradeItem.tsx
@@ -88,11 +88,13 @@ export default function UpgradeItem({ selectedUnit, upgrade, option }: { selecte
             const count = group.length
 
             return <UpgradeItemDisplay key={i} eqp={e} count={count} />;
-          }) : upgrade.replaceWhat && upgrade.type == "replace" ? 
-          upgrade.replaceWhat.map((e, i) => {
-            return <UpgradeItemDisplay key={`d${i}`} eqp={{...EquipmentService.findLast(selectedUnit.equipment, e), type:"ArmyBookWeapon"}} count={1} />
-          })
-          : <span style={{ color: "#000000" }}>None</span>
+          }) : <span style={{ color: "#000000" }}>{
+            upgrade.replaceWhat && upgrade.type == "replace" ? 
+              <>Keep {upgrade.replaceWhat.map((e, i) => {
+                let w = EquipmentService.findLast(selectedUnit.equipment, e)
+                return `${w ? EquipmentService.formatString(w) : e} `
+              })}</>
+            : "None"}</span>
         }
       </div>
       <div>


### PR DESCRIPTION
Made default item on 'replace...' type upgrades show the details of the item being replaced (and prepend the word "Keep" for clarity).  May want to have a style pass. 👍 

![Screenshot 2021-11-04 161220](https://user-images.githubusercontent.com/23005404/140377002-1e37d686-bb2a-4122-b6fa-10a36544929d.png)

Closes #177 