### PR TITLE
Fix for #185 - Validation checks updated

### DIFF
--- a/services/ValidationService.ts
+++ b/services/ValidationService.ts
@@ -17,7 +17,7 @@ export default class ValidationService {
 
     if (army.gameSystem === "gf") {
 
-      const unitCount = list.units.filter(u => !u.joinToUnit).length;
+      const unitCount = list.units.filter(u => !(u.combined && (!u.joinToUnit))).length;
       const heroCount = list.units.filter(u => u.specialRules.findIndex(rule => rule.name === "Hero") >= 0).length;
 
       if (heroCount > Math.floor(points / 500))
@@ -26,8 +26,8 @@ export default class ValidationService {
         errors.push(`Max 1 unit per full 200pts (combined units count as just 1 unit).`);
       if (list.units.some(u => u.combined && u.size === 2))
         errors.push(`Cannot combine units of unit size [1].`);
-      if (Object.values(_.groupBy(list.units, u => u.name)).some((grp: any[]) => grp.length > 3))
-        errors.push(`Cannot have more than 3 copies of a particular unit.`);
+      if (Object.values(_.groupBy(list.units.filter(u => !(u.combined && (!u.joinToUnit))), u => u.name)).some((grp: any[]) => grp.length > 3))
+        errors.push(`Cannot have more than 3 copies of a particular unit.`); // combined units still count as one
     }
 
     return errors;

--- a/services/ValidationService.ts
+++ b/services/ValidationService.ts
@@ -23,7 +23,7 @@ export default class ValidationService {
       if (heroCount > Math.floor(points / 500))
         errors.push(`Max 1 hero per full 500pts.`);
       if (unitCount > Math.floor(points / 200))
-        errors.push(`Max 1 unit per full 200pts (combined units count as just 1 unit).`);
+        errors.push(`Max 1 unit per full 200pts (combined units count as just 1 unit).`); // should Heroes joined to other units count as 'combined' too or not?
       if (list.units.some(u => u.combined && u.size === 2))
         errors.push(`Cannot combine units of unit size [1].`);
       if (Object.values(_.groupBy(list.units.filter(u => !(u.combined && (!u.joinToUnit))), u => u.name)).some((grp: any[]) => grp.length > 3))


### PR DESCRIPTION
More accurately counts units (no longer ignores attached heroes).
Doesn't include combined units in the "max 3 of a unit" check.

Closes #185 