### PR TITLE
Several adjustments to list page

### DIFF
--- a/pages/files.tsx
+++ b/pages/files.tsx
@@ -195,8 +195,8 @@ export default function Files() {
           </Toolbar>
         </AppBar>
       </Paper>
-      <div className="container">
-        <div className="mx-auto p-4">
+      <div className="container" style={{width: "100vw", maxWidth: "unset"}}>
+        <div className="mx-auto p-4" style={{maxWidth: "960px"}}>
           <h3 className="is-size-4 has-text-centered mb-4 pt-4">Choose your army</h3>
           {
             army.gameSystem === "gf" && (

--- a/pages/files.tsx
+++ b/pages/files.tsx
@@ -195,84 +195,86 @@ export default function Files() {
           </Toolbar>
         </AppBar>
       </Paper>
-      <div className="container" style={{width: "100vw", maxWidth: "unset"}}>
-        <div className="mx-auto p-4" style={{maxWidth: "960px"}}>
-          <h3 className="is-size-4 has-text-centered mb-4 pt-4">Choose your army</h3>
-          {
-            army.gameSystem === "gf" && (
-              <>
-                {!officialArmies && <div className="column is-flex is-flex-direction-column is-align-items-center	">
-                  <CircularProgress />
-                  <p>Loading armies...</p>
-                </div>}
-                {officialArmies && <>
-                  <div className="columns is-mobile is-multiline">
-                    {gfSection(_.sortBy(officialActiveArmies, a => a.name), true)}
-                  </div>
-                  {officialInactiveArmies.length > 0 && <>
-                    <h3 className="is-size-4 has-text-centered mb-4 pt-4">Coming Soon...</h3>
-                    <div className="columns is-mobile is-multiline">
-                      {gfSection(officialInactiveArmies, false)}
-                    </div>
-                  </>}
-                </>}
-              </>
-            )
-          }
-          <div className="columns is-mobile is-multiline">
+      <div className="scrolling appContent">
+        <div className="container">
+          <div className="mx-auto p-4">
+            <h3 className="is-size-4 has-text-centered mb-4 pt-4">Choose your army</h3>
             {
-              army.gameSystem === "gf" || !armyFiles ? null : armies.map((file, index) => {
-                const driveArmy = driveArmies && driveArmies.filter(army => file.name.toUpperCase() === army?.name?.toUpperCase())[0];
-
-                return (
-                  <Tile
-                    key={index}
-                    army={file}
-                    enabled={true}
-                    driveArmy={driveArmy}
-                    onSelect={army => selectArmy(army.path)} />
-                );
-              })
-            }
-          </div>
-          {!isLive && (customArmies ? (
-            <>
-              <h3>Custom Armies</h3>
-              <div className="columns is-multiline">
-                {customArmies.filter(a => a.official === false).map((customArmy, i) => (
-                  <div key={i} className="column is-half">
-                    <Card
-                      elevation={1}
-                      className="interactable"
-                      style={{
-                        backgroundColor: customArmy.official ? "#F9FDFF" : null,
-                        borderLeft: customArmy.official ? "2px solid #0F71B4" : null,
-                      }}
-                      onClick={(e) => { e.stopPropagation(); selectCustomList(customArmy); }}>
-                      <div className="is-flex is-flex-grow-1 is-align-items-center p-4">
-                        <div className="is-flex-grow-1">
-                          <p className="mb-1" style={{ fontWeight: 600 }}>{customArmy.name}</p>
-                          <div className="is-flex" style={{ fontSize: "14px", color: "#666" }}>
-                            {customArmy.versionString} by {customArmy.username}
-                          </div>
-                        </div>
-                        {/* <p className="mr-2">{u.cost}pts</p> */}
-                        <IconButton color="primary">
-                          <RightIcon />
-                        </IconButton>
+              army.gameSystem === "gf" && (
+                <>
+                  {!officialArmies && <div className="column is-flex is-flex-direction-column is-align-items-center	">
+                    <CircularProgress />
+                    <p>Loading armies...</p>
+                  </div>}
+                  {officialArmies && <>
+                    <div className="columns is-mobile is-multiline">
+                      {gfSection(_.sortBy(officialActiveArmies, a => a.name), true)}
+                    </div>
+                    {officialInactiveArmies.length > 0 && <>
+                      <h3 className="is-size-4 has-text-centered mb-4 pt-4">Coming Soon...</h3>
+                      <div className="columns is-mobile is-multiline">
+                        {gfSection(officialInactiveArmies, false)}
                       </div>
-                    </Card>
-                  </div>
-                ))}
-              </div>
-            </>
-          ) : (
-            <div className="is-flex is-flex-direction-column is-align-items-center	">
-              <CircularProgress />
-              <p>Loading custom armies...</p>
+                    </>}
+                  </>}
+                </>
+              )
+            }
+            <div className="columns is-mobile is-multiline">
+              {
+                army.gameSystem === "gf" || !armyFiles ? null : armies.map((file, index) => {
+                  const driveArmy = driveArmies && driveArmies.filter(army => file.name.toUpperCase() === army?.name?.toUpperCase())[0];
+
+                  return (
+                    <Tile
+                      key={index}
+                      army={file}
+                      enabled={true}
+                      driveArmy={driveArmy}
+                      onSelect={army => selectArmy(army.path)} />
+                  );
+                })
+              }
             </div>
-          )
-          )}
+            {!isLive && (customArmies ? (
+              <>
+                <h3>Custom Armies</h3>
+                <div className="columns is-multiline">
+                  {customArmies.filter(a => a.official === false).map((customArmy, i) => (
+                    <div key={i} className="column is-half">
+                      <Card
+                        elevation={1}
+                        className="interactable"
+                        style={{
+                          backgroundColor: customArmy.official ? "#F9FDFF" : null,
+                          borderLeft: customArmy.official ? "2px solid #0F71B4" : null,
+                        }}
+                        onClick={(e) => { e.stopPropagation(); selectCustomList(customArmy); }}>
+                        <div className="is-flex is-flex-grow-1 is-align-items-center p-4">
+                          <div className="is-flex-grow-1">
+                            <p className="mb-1" style={{ fontWeight: 600 }}>{customArmy.name}</p>
+                            <div className="is-flex" style={{ fontSize: "14px", color: "#666" }}>
+                              {customArmy.versionString} by {customArmy.username}
+                            </div>
+                          </div>
+                          {/* <p className="mr-2">{u.cost}pts</p> */}
+                          <IconButton color="primary">
+                            <RightIcon />
+                          </IconButton>
+                        </div>
+                      </Card>
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <div className="is-flex is-flex-direction-column is-align-items-center	">
+                <CircularProgress />
+                <p>Loading custom armies...</p>
+              </div>
+            )
+            )}
+          </div>
         </div>
       </div>
       <ListConfigurationDialog

--- a/pages/gameSystem.tsx
+++ b/pages/gameSystem.tsx
@@ -51,7 +51,7 @@ export default function GameSystem() {
           </Toolbar>
         </AppBar>
       </Paper>
-      <div className="container">
+      <div className="container" style={{overflow: "auto", height: "calc(100vh - 56px)"}}>
         <div className="mx-auto p-4" style={{ maxWidth: "480px" }}>
           <h3 className="is-size-4 has-text-centered mb-4">Select Game System</h3>
           <div className="columns is-multiline is-mobile">

--- a/pages/gameSystem.tsx
+++ b/pages/gameSystem.tsx
@@ -51,7 +51,7 @@ export default function GameSystem() {
           </Toolbar>
         </AppBar>
       </Paper>
-      <div className="container" style={{overflow: "auto", height: "calc(100vh - 56px)"}}>
+      <div className="container">
         <div className="mx-auto p-4" style={{ maxWidth: "480px" }}>
           <h3 className="is-size-4 has-text-centered mb-4">Select Game System</h3>
           <div className="columns is-multiline is-mobile">

--- a/pages/gameSystem.tsx
+++ b/pages/gameSystem.tsx
@@ -51,25 +51,27 @@ export default function GameSystem() {
           </Toolbar>
         </AppBar>
       </Paper>
-      <div className="container">
-        <div className="mx-auto p-4" style={{ maxWidth: "480px" }}>
-          <h3 className="is-size-4 has-text-centered mb-4">Select Game System</h3>
-          <div className="columns is-multiline is-mobile">
-            {
-              // For each game system
-              gameSystems.map(gameSystem => (
-                <div key={gameSystem} className="column is-half">
-                  <Paper>
-                    <img onClick={() => isLive && gameSystem !== "gf" ? false : selectGameSystem(gameSystem)} src={`img/${gameSystem}_cover.jpg`}
-                      className={"game-system-tile "+ (isLive && gameSystem !== "gf" ? "" : "interactable")}
-                      style={{ borderRadius: "4px", display: "block", filter: isLive && gameSystem !== "gf" ? "grayscale(95%)" : null }} />
-                  </Paper>
-                </div>
-              ))
-            }
+      <div className="scrolling appContent">
+        <div className="container">
+          <div className="mx-auto p-4" style={{ maxWidth: "480px" }}>
+            <h3 className="is-size-4 has-text-centered mb-4">Select Game System</h3>
+            <div className="columns is-multiline is-mobile">
+              {
+                // For each game system
+                gameSystems.map(gameSystem => (
+                  <div key={gameSystem} className="column is-half">
+                    <Paper>
+                      <img onClick={() => isLive && gameSystem !== "gf" ? false : selectGameSystem(gameSystem)} src={`img/${gameSystem}_cover.jpg`}
+                        className={"game-system-tile "+ (isLive && gameSystem !== "gf" ? "" : "interactable")}
+                        style={{ borderRadius: "4px", display: "block", filter: isLive && gameSystem !== "gf" ? "grayscale(95%)" : null }} />
+                    </Paper>
+                  </div>
+                ))
+              }
+            </div>
           </div>
-        </div>
 
+        </div>
       </div>
     </>
   );

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -14,8 +14,6 @@
   background-size: cover;
   background-position: center;
   max-width: none !important;
-  max-height: none !important;
-  height: unset !important;
 }
 
 @media (min-width: 1440px) {

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -14,6 +14,8 @@
   background-size: cover;
   background-position: center;
   max-width: none !important;
+  max-height: none !important;
+  height: unset !important;
 }
 
 @media (min-width: 1440px) {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,8 +19,11 @@ a {
   font-family: "Source Sans Pro", sans-serif;
 }
 
-.container {
+.scrolling {
   overflow: auto;
+}
+
+.appContent {
   height: calc(100vh - 56px);
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,7 @@ body {
   margin: 0;
   height: 100%;
   background-color: #FAFAFA;
+  overflow: hidden;
 }
 
 a {
@@ -16,6 +17,11 @@ a {
 * {
   box-sizing: border-box;
   font-family: "Source Sans Pro", sans-serif;
+}
+
+.container {
+  overflow: auto;
+  height: calc(100vh - 56px);
 }
 
 .full-compact-text {

--- a/views/MainList.tsx
+++ b/views/MainList.tsx
@@ -15,7 +15,7 @@ import LinkIcon from '@mui/icons-material/Link';
 import _ from "lodash";
 import { GroupSharp } from "@mui/icons-material";
 
-export function MainList({ onSelected, onUnitRemoved, scrollOnAdd = false }) {
+export function MainList({ onSelected, onUnitRemoved, scrollOnAdd = false, Mobile=false }) {
 
   const list = useSelector((state: RootState) => state.list);
 
@@ -47,7 +47,7 @@ export function MainList({ onSelected, onUnitRemoved, scrollOnAdd = false }) {
         <h3 className="px-4 pt-4 is-size-4 is-hidden-mobile">{`My List - ${list.points}` + (list.pointsLimit ? `/${list.pointsLimit}` : "") + "pts"}</h3>
         <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />
       </div>
-      <div style={{overflowY: "scroll", flexFlow: "column", display: "flex", flex: "1 1 auto"}}>
+      <div className="scrolling" style={{height: Mobile ? "calc(100vh - 148px)" : "calc(100vh - 156px)"}}>
 
         <ul className="mt-2">
           {

--- a/views/UnitSelection.tsx
+++ b/views/UnitSelection.tsx
@@ -13,7 +13,7 @@ import { IUnit } from "../data/interfaces";
 import { useMediaQuery } from "react-responsive";
 import FullCompactToggle from "./components/FullCompactToggle";
 
-export function UnitSelection({ onAdded = (unit) => {}, onSelected = (unit) => {} }) {
+export function UnitSelection({ onAdded = (unit) => {}, onSelected = (unit) => {}, Mobile = false }) {
 
   // Access the main army definition state
   const armyData = useSelector((state: RootState) => state.army);
@@ -86,7 +86,7 @@ export function UnitSelection({ onAdded = (unit) => {}, onSelected = (unit) => {
 
         <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />
       </div>
-      <div style={isBigScreen ? scrolling: null}>
+      <div className="scrolling" style={{height: Mobile ? "calc(100vh - 148px)" : "calc(100vh - 156px)"}}>
         {
           // For each category
           Object.keys(unitGroups).map((key, i) => (

--- a/views/components/MainMenu.tsx
+++ b/views/components/MainMenu.tsx
@@ -55,100 +55,102 @@ export default function MainMenu({ setListConfigurationOpen, setValidationOpen }
   const isBigScreen = useMediaQuery({ query: '(min-width: 1024px)' });
 
   return (
-    <>
-      <AppBar elevation={0} style={{ position: "sticky", top: 0, zIndex: 1 }}>
-        <Toolbar className="p-0">
-          <IconButton
-            size="large"
-            edge="start"
-            color="inherit"
-            aria-label="menu"
-            onClick={() => router.back()}
-            style={{ marginLeft: "0" }}
-          >
-            <BackIcon />
-          </IconButton>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-            {list.name}
-          </Typography>
-          {errors.length > 0 && <>
+    <div style={{maxHeight: "64px"}}>
+      <Paper elevation={1} color="primary" square>
+        <AppBar elevation={0} style={{ position: "sticky", top: 0, zIndex: 1 }}>
+          <Toolbar className="p-0">
             <IconButton
               size="large"
+              edge="start"
               color="inherit"
-              title="Validation warnings"
-              style={{ backgroundColor: Boolean(validationAnchorElement) ? "#6EAAE7" : null }}
-              onClick={e => setValidationAnchorElement(e.currentTarget)}
-              className="mr-2 p-2"
+              aria-label="menu"
+              onClick={() => router.back()}
+              style={{ marginLeft: "0" }}
             >
-              <NotificationImportantIcon />
+              <BackIcon />
             </IconButton>
-            <Popper
-              placement="bottom-end"
-              anchorEl={validationAnchorElement}
-              open={Boolean(validationAnchorElement) && isBigScreen}
-            // onClose={_ => setValidationAnchorElement(null)}
-            >
-              <ClickAwayListener onClickAway={_ => setValidationAnchorElement(null)}>
-                <Paper>
-                  <List>
-                    <ListItem divider>
-                      <ListItemText>
-                        <span style={{ fontWeight: 600 }}>Competitive List Validation</span>
-                      </ListItemText>
-                    </ListItem>
-                    {errors.map((error, index) => (
-                      <ListItem key={index} className="mx-4 px-0" style={{ width: "auto" }} divider={index < errors.length - 1}>
-                        <ListItemText>{error}</ListItemText>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+              {list.name}
+            </Typography>
+            {errors.length > 0 && <>
+              <IconButton
+                size="large"
+                color="inherit"
+                title="Validation warnings"
+                style={{ backgroundColor: Boolean(validationAnchorElement) ? "#6EAAE7" : null }}
+                onClick={e => setValidationAnchorElement(e.currentTarget)}
+                className="mr-2 p-2"
+              >
+                <NotificationImportantIcon />
+              </IconButton>
+              <Popper
+                placement="bottom-end"
+                anchorEl={validationAnchorElement}
+                open={Boolean(validationAnchorElement) && isBigScreen}
+              // onClose={_ => setValidationAnchorElement(null)}
+              >
+                <ClickAwayListener onClickAway={_ => setValidationAnchorElement(null)}>
+                  <Paper>
+                    <List>
+                      <ListItem divider>
+                        <ListItemText>
+                          <span style={{ fontWeight: 600 }}>Competitive List Validation</span>
+                        </ListItemText>
                       </ListItem>
-                    ))}
-                  </List>
-                </Paper>
-              </ClickAwayListener>
-            </Popper>
-          </>}
-          {isBigScreen && <IconButton
-            size="large"
-            color="inherit"
-            aria-label="menu"
-            title="View list"
-            onClick={() => router.push("/view")}
-            className="mr-2"
-          >
-            <VisibilityIcon />
-          </IconButton>}
-          <IconButton
-            size="large"
-            edge="start"
-            color="inherit"
-            aria-label="menu"
-            onClick={e => setMenuAnchorElement(e.currentTarget)}
-          >
-            <MoreVertIcon />
-          </IconButton>
-          <Menu
-            id="menu-appbar"
-            anchorEl={menuAnchorElement}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-            keepMounted
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-            open={Boolean(menuAnchorElement)}
-            onClose={_ => setMenuAnchorElement(null)}
-          >
-            <MenuItem onClick={() => setListConfigurationOpen(true)}>Edit Details</MenuItem>
-            <MenuItem onClick={() => router.push("/view")}>View</MenuItem>
-            {!list.creationTime && <MenuItem onClick={handleSave}>Save</MenuItem>}
-            <MenuItem onClick={handleShare}>Export as Army Forge File</MenuItem>
-            <MenuItem onClick={handleTextExport}>Export as Text</MenuItem>
-            <MenuItem onClick={handleLoad}>Load</MenuItem>
-          </Menu>
-        </Toolbar>
-      </AppBar>
+                      {errors.map((error, index) => (
+                        <ListItem key={index} className="mx-4 px-0" style={{ width: "auto" }} divider={index < errors.length - 1}>
+                          <ListItemText>{error}</ListItemText>
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Paper>
+                </ClickAwayListener>
+              </Popper>
+            </>}
+            {isBigScreen && <IconButton
+              size="large"
+              color="inherit"
+              aria-label="menu"
+              title="View list"
+              onClick={() => router.push("/view")}
+              className="mr-2"
+            >
+              <VisibilityIcon />
+            </IconButton>}
+            <IconButton
+              size="large"
+              edge="start"
+              color="inherit"
+              aria-label="menu"
+              onClick={e => setMenuAnchorElement(e.currentTarget)}
+            >
+              <MoreVertIcon />
+            </IconButton>
+            <Menu
+              id="menu-appbar"
+              anchorEl={menuAnchorElement}
+              anchorOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              keepMounted
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+              open={Boolean(menuAnchorElement)}
+              onClose={_ => setMenuAnchorElement(null)}
+            >
+              <MenuItem onClick={() => setListConfigurationOpen(true)}>Edit Details</MenuItem>
+              <MenuItem onClick={() => router.push("/view")}>View</MenuItem>
+              {!list.creationTime && <MenuItem onClick={handleSave}>Save</MenuItem>}
+              <MenuItem onClick={handleShare}>Export as Army Forge File</MenuItem>
+              <MenuItem onClick={handleTextExport}>Export as Text</MenuItem>
+              <MenuItem onClick={handleLoad}>Load</MenuItem>
+            </Menu>
+          </Toolbar>
+        </AppBar>
+      </Paper>
       <ValidationErrors open={Boolean(validationAnchorElement) && !isBigScreen} setOpen={setValidationAnchorElement} />
       <Snackbar
         open={showTextCopiedAlert}
@@ -156,6 +158,6 @@ export default function MainMenu({ setListConfigurationOpen, setValidationOpen }
         message="Army list copied to your clipboard."
         anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         autoHideDuration={4000} />
-    </>
+    </div>
   );
 }

--- a/views/components/UpgradePanelHeader.tsx
+++ b/views/components/UpgradePanelHeader.tsx
@@ -22,6 +22,12 @@ export default function UpgradePanelHeader() {
     setCustomName(selectedUnit?.customName ?? selectedUnit?.name ?? "");
   }, [selectedUnit?.selectionId]);
 
+  const debounceSaveMemo = useCallback(
+    debounce(1000, 
+      (name) => dispatch(renameUnit({ unitId: selectedUnit.selectionId, name }))
+    )
+    , [list]);
+
   if (!selectedUnit)
     return null;
 
@@ -33,10 +39,6 @@ export default function UpgradePanelHeader() {
     }
   };
 
-  const debounceSave = debounce(1000, (name) => {
-    dispatch(renameUnit({ unitId: selectedUnit.selectionId, name }));
-  });
-
   return (
     <Paper className="px-4 pt-4">
     <div className="is-flex is-align-items-center">
@@ -46,7 +48,7 @@ export default function UpgradePanelHeader() {
           variant="standard"
           className=""
           value={customName}
-          onChange={e => { setCustomName(e.target.value); debounceSave(e.target.value); }}
+          onChange={e => { setCustomName(e.target.value); debounceSaveMemo(e.target.value); }}
         />
       ) : (
         <div className="is-flex">

--- a/views/components/UpgradePanelHeader.tsx
+++ b/views/components/UpgradePanelHeader.tsx
@@ -9,7 +9,7 @@ import { RootState } from "../../data/store";
 import UnitService from "../../services/UnitService";
 import { debounce } from 'throttle-debounce';
 
-export default function UpgradePanelHeader() {
+export default function UpgradePanelHeader({Mobile = false}) {
 
   const list = useSelector((state: RootState) => state.list);
   const dispatch = useDispatch();

--- a/views/components/UpgradePanelHeader.tsx
+++ b/views/components/UpgradePanelHeader.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { useDispatch, useSelector } from 'react-redux'
-import { IconButton, TextField } from "@mui/material";
+import { IconButton, Paper, TextField } from "@mui/material";
 import EditIcon from '@mui/icons-material/Create';
 import UpgradeService from "../../services/UpgradeService";
 import { renameUnit } from "../../data/listSlice";
@@ -33,11 +33,12 @@ export default function UpgradePanelHeader() {
     }
   };
 
-  const debounceSave = debounce(1000, (name) => {
+  const debounceSave = useCallback(debounce(1000, (name) => {
     dispatch(renameUnit({ unitId: selectedUnit.selectionId, name }));
-  });
+  }), []);
 
   return (
+    <Paper className="px-4 pt-4">
     <div className="is-flex is-align-items-center">
       {editMode ? (
         <TextField
@@ -57,5 +58,6 @@ export default function UpgradePanelHeader() {
       </IconButton>
       <p className="ml-4 is-flex-grow-1" style={{ textAlign: "right" }}>{UpgradeService.calculateUnitTotal(selectedUnit)}pts</p>
     </div>
+    </Paper>
   );
 }

--- a/views/components/UpgradePanelHeader.tsx
+++ b/views/components/UpgradePanelHeader.tsx
@@ -33,9 +33,9 @@ export default function UpgradePanelHeader() {
     }
   };
 
-  const debounceSave = useCallback(debounce(1000, (name) => {
+  const debounceSave = debounce(1000, (name) => {
     dispatch(renameUnit({ unitId: selectedUnit.selectionId, name }));
-  }), []);
+  });
 
   return (
     <Paper className="px-4 pt-4">

--- a/views/listBuilder/DesktopView.tsx
+++ b/views/listBuilder/DesktopView.tsx
@@ -10,8 +10,6 @@ import UpgradePanelHeader from "../components/UpgradePanelHeader";
 import ListConfigurationDialog from "../ListConfigurationDialog";
 import ValidationErrors from "../ValidationErrors";
 import UndoRemoveUnit from "../components/UndoRemoveUnit";
-import { flexbox } from "@mui/system";
-import { Calculate } from "@mui/icons-material";
 
 export default function DesktopView() {
 

--- a/views/listBuilder/DesktopView.tsx
+++ b/views/listBuilder/DesktopView.tsx
@@ -24,7 +24,7 @@ export default function DesktopView() {
   return (
     <>
     <MainMenu setListConfigurationOpen={setEditListOpen} setValidationOpen={setValidationOpen} />
-    <div className="container" style={{overflow: "clip", maxHeight: "100vh", maxWidth: "100vw"}}>
+    <div className="appContent">
       <div className="columns my-0" style={{ flex: "1 0 auto", maxHeight: "calc(100vh - 64px)" }}>
         <div className="column py-0 pr-0" style={columnStyle}>
           <UnitSelection onAdded={() => { }} />

--- a/views/listBuilder/DesktopView.tsx
+++ b/views/listBuilder/DesktopView.tsx
@@ -10,6 +10,8 @@ import UpgradePanelHeader from "../components/UpgradePanelHeader";
 import ListConfigurationDialog from "../ListConfigurationDialog";
 import ValidationErrors from "../ValidationErrors";
 import UndoRemoveUnit from "../components/UndoRemoveUnit";
+import { flexbox } from "@mui/system";
+import { Calculate } from "@mui/icons-material";
 
 export default function DesktopView() {
 
@@ -18,25 +20,22 @@ export default function DesktopView() {
   const [validationOpen, setValidationOpen] = useState(false);
   const [showUndoRemove, setShowUndoRemove] = useState(false);
 
-  const columnStyle: any = { overflowY: "scroll", maxHeight: "100%" };
+  const columnStyle: any = { display:"flex", flexDirection: "column", overflowY: "hidden", width: "calc(100% / 3)"};
+  //const stickyHeader: any = { position: "sticky", top: 0, backgroundColor: "#FAFAFA", zIndex: 10 };
 
   return (
     <>
-      <Paper elevation={1} color="primary" square>
-        <MainMenu setListConfigurationOpen={setEditListOpen} setValidationOpen={setValidationOpen} />
-      </Paper>
-      <div className="columns my-0" style={{ height: "calc(100vh - 64px)" }}>
+    <MainMenu setListConfigurationOpen={setEditListOpen} setValidationOpen={setValidationOpen} />
+    <div className="container" style={{overflow: "clip", maxHeight: "100vh", maxWidth: "100vw"}}>
+      <div className="columns my-0" style={{ flex: "1 0 auto", maxHeight: "calc(100vh - 64px)" }}>
         <div className="column py-0 pr-0" style={columnStyle}>
-          <UnitSelection onSelected={() => { }} />
+          <UnitSelection onAdded={() => { }} />
         </div>
         <div className="column p-0" style={columnStyle}>
-          <h3 className="px-4 pt-4 is-size-4 is-hidden-mobile">{`My List - ${list.points}` + (list.pointsLimit ? `/${list.pointsLimit}` : "") + "pts"}</h3>
-          <MainList onSelected={() => { }} onUnitRemoved={() => setShowUndoRemove(true)} />
+          <MainList onSelected={() => { }} onUnitRemoved={() => setShowUndoRemove(true)} scrollOnAdd />
         </div>
         <div className="column py-0 px-0 mr-4" style={columnStyle}>
-          <Paper square className="px-4 pt-4">
-            <UpgradePanelHeader />
-          </Paper>
+          <UpgradePanelHeader />
           <Upgrades />
         </div>
       </div>
@@ -51,6 +50,7 @@ export default function DesktopView() {
       <UndoRemoveUnit
         open={showUndoRemove}
         setOpen={setShowUndoRemove} />
+    </div>
     </>
   );
 }

--- a/views/listBuilder/MobileView.tsx
+++ b/views/listBuilder/MobileView.tsx
@@ -62,22 +62,24 @@ export default function MobileView() {
 
   return (
     <>
-      <Paper elevation={1} color="primary" square style={{ position: "sticky", top: 0, zIndex: 1 }}>
-        <MainMenu setListConfigurationOpen={setEditListOpen} setValidationOpen={setValidationOpen} />
-        <AppBar elevation={0} style={{ position: "sticky", top: 0, zIndex: 1 }}>
-          <Tabs value={slideIndex} onChange={handleSlideChange} centered variant="fullWidth" textColor="inherit" indicatorColor="primary">
-            <Tab label={`${army?.data?.name} ${army?.data?.versionString}`} />
-            <Tab label={`My List - ${list.points}pts`} />
-          </Tabs>
-        </AppBar>
-      </Paper>
+    <MainMenu setListConfigurationOpen={setEditListOpen} setValidationOpen={setValidationOpen} />
 
-      <Slider {...sliderSettings} ref={slider => setSlider(slider)} style={{ maxHeight: "100%" }}>
+    <Paper elevation={1} color="primary" square style={{ position: "sticky", top: 0, zIndex: 1 }}>
+      <AppBar elevation={0} style={{ position: "sticky", top: 0, zIndex: 1 }}>
+        <Tabs value={slideIndex} onChange={handleSlideChange} centered variant="fullWidth" textColor="inherit" indicatorColor="primary">
+          <Tab label={`${army?.data?.name} ${army?.data?.versionString}`} />
+          <Tab label={`My List - ${list.points}pts`} />
+        </Tabs>
+      </AppBar>
+    </Paper>
+
+    <div className="container">
+      <Slider {...sliderSettings} ref={slider => setSlider(slider)} style={{ maxHeight: "calc(100vh - 48px - 56px)" }}>
         <div>
-          <UnitSelection onSelected={() => { }} />
+          <UnitSelection onAdded={(unit) => { }} />
         </div>
         <div className="">
-          {list.units.length > 0 ? <MainList onSelected={onUnitSelected} onUnitRemoved={() => setShowUndoRemove(true)} /> : (
+          {list.units.length > 0 ? <MainList onSelected={onUnitSelected} onUnitRemoved={() => setShowUndoRemove(true)}  /> : (
             <div className="p-4 has-text-centered">
               <h3 className="is-size-3 mb-4">Your list is empty</h3>
               <Button variant="outlined" onClick={() => handleSlideChange(null, 0)}>
@@ -127,6 +129,7 @@ export default function MobileView() {
       <UndoRemoveUnit
         open={showUndoRemove}
         setOpen={setShowUndoRemove} />
+    </div>
     </>
   );
 }

--- a/views/listBuilder/MobileView.tsx
+++ b/views/listBuilder/MobileView.tsx
@@ -64,72 +64,73 @@ export default function MobileView() {
     <>
     <MainMenu setListConfigurationOpen={setEditListOpen} setValidationOpen={setValidationOpen} />
 
-    <Paper elevation={1} color="primary" square style={{ position: "sticky", top: 0, zIndex: 1 }}>
-      <AppBar elevation={0} style={{ position: "sticky", top: 0, zIndex: 1 }}>
-        <Tabs value={slideIndex} onChange={handleSlideChange} centered variant="fullWidth" textColor="inherit" indicatorColor="primary">
-          <Tab label={`${army?.data?.name} ${army?.data?.versionString}`} />
-          <Tab label={`My List - ${list.points}pts`} />
-        </Tabs>
-      </AppBar>
-    </Paper>
+    <div className="appContent">
+      <Paper elevation={1} color="primary" square style={{ position: "sticky", top: 0, zIndex: 1 }}>
+        <AppBar elevation={0} style={{ position: "sticky", top: 0, zIndex: 1 }}>
+          <Tabs value={slideIndex} onChange={handleSlideChange} centered variant="fullWidth" textColor="inherit" indicatorColor="primary">
+            <Tab label={`${army?.data?.name} ${army?.data?.versionString}`} />
+            <Tab label={`My List - ${list.points}pts`} />
+          </Tabs>
+        </AppBar>
+      </Paper>
 
-    <div className="container">
-      <Slider {...sliderSettings} ref={slider => setSlider(slider)} style={{ maxHeight: "calc(100vh - 48px - 56px)" }}>
-        <div>
-          <UnitSelection onAdded={(unit) => { }} />
-        </div>
-        <div className="">
-          {list.units.length > 0 ? <MainList onSelected={onUnitSelected} onUnitRemoved={() => setShowUndoRemove(true)}  /> : (
-            <div className="p-4 has-text-centered">
-              <h3 className="is-size-3 mb-4">Your list is empty</h3>
-              <Button variant="outlined" onClick={() => handleSlideChange(null, 0)}>
-                <Add /> Add Units
-              </Button>
-              <div className="is-flex mt-6" style={{
-                height: "160px",
-                width: "100%",
-                backgroundImage: `url("img/gf_armies/${army?.data?.name}.png")`,
-                backgroundPosition: "center",
-                backgroundSize: "contain",
-                backgroundRepeat: 'no-repeat',
-                position: "relative",
-                zIndex: 1,
-                opacity: 0.5
-              }}></div>
-            </div>
-          )}
-        </div>
-      </Slider>
-
-      <BottomSheet
-        open={sheetOpen}
-        onDismiss={onDismissSheet}
-        initialFocusRef={false}
-        expandOnContentDrag={true}
-        onScrollCapture={(e) => e.preventDefault()}
-        defaultSnap={({ snapPoints, lastSnap }) =>
-          lastSnap ?? Math.min(...snapPoints)
-        }
-        snapPoints={({ minHeight, maxHeight }) => [
-          minHeight,
-          maxHeight * 0.9
-        ]}
-        header={<UpgradePanelHeader />}>
-        <Upgrades Mobile />
-      </BottomSheet>
-
-      <ValidationErrors
-        open={validationOpen}
-        setOpen={setValidationOpen} />
-      <ListConfigurationDialog
-        isEdit={true}
-        open={editListOpen}
-        setOpen={setEditListOpen}
-        customArmies={null} />
-      <UndoRemoveUnit
-        open={showUndoRemove}
-        setOpen={setShowUndoRemove} />
+      <div className="container">
+        <Slider {...sliderSettings} ref={slider => setSlider(slider)}>
+          <div>
+            <UnitSelection onAdded={(unit) => { }} />
+          </div>
+          <div>
+            {list.units.length > 0 ? <MainList onSelected={onUnitSelected} onUnitRemoved={() => setShowUndoRemove(true)}  /> : (
+              <div className="p-4 has-text-centered">
+                <h3 className="is-size-3 mb-4">Your list is empty</h3>
+                <Button variant="outlined" onClick={() => handleSlideChange(null, 0)}>
+                  <Add /> Add Units
+                </Button>
+                <div className="is-flex mt-6" style={{
+                  height: "160px",
+                  width: "100%",
+                  backgroundImage: `url("img/gf_armies/${army?.data?.name}.png")`,
+                  backgroundPosition: "center",
+                  backgroundSize: "contain",
+                  backgroundRepeat: 'no-repeat',
+                  position: "relative",
+                  zIndex: 1,
+                  opacity: 0.5
+                }}></div>
+              </div>
+            )}
+          </div>
+        </Slider>
+      </div>
     </div>
+    <BottomSheet
+      open={sheetOpen}
+      onDismiss={onDismissSheet}
+      initialFocusRef={false}
+      expandOnContentDrag={true}
+      onScrollCapture={(e) => e.preventDefault()}
+      defaultSnap={({ snapPoints, lastSnap }) =>
+        lastSnap ?? Math.min(...snapPoints)
+      }
+      snapPoints={({ minHeight, maxHeight }) => [
+        minHeight,
+        maxHeight * 0.9
+      ]}
+      header={<UpgradePanelHeader Mobile />}>
+      <Upgrades Mobile />
+    </BottomSheet>
+
+    <ValidationErrors
+      open={validationOpen}
+      setOpen={setValidationOpen} />
+    <ListConfigurationDialog
+      isEdit={true}
+      open={editListOpen}
+      setOpen={setEditListOpen}
+      customArmies={null} />
+    <UndoRemoveUnit
+      open={showUndoRemove}
+      setOpen={setShowUndoRemove} />
     </>
   );
 }

--- a/views/listBuilder/MobileView.tsx
+++ b/views/listBuilder/MobileView.tsx
@@ -115,7 +115,7 @@ export default function MobileView() {
           maxHeight * 0.9
         ]}
         header={<UpgradePanelHeader />}>
-        <Upgrades />
+        <Upgrades Mobile />
       </BottomSheet>
 
       <ValidationErrors

--- a/views/upgrades/Upgrades.tsx
+++ b/views/upgrades/Upgrades.tsx
@@ -15,7 +15,7 @@ import UpgradeService from '../../services/UpgradeService';
 import LinkIcon from '@mui/icons-material/Link';
 import UpgradePanelHeader from "../components/UpgradePanelHeader";
 
-export function Upgrades() {
+export function Upgrades({Mobile = false}) {
 
   const list = useSelector((state: RootState) => state.list);
   const gameSystem = useSelector((state: RootState) => state.army.gameSystem);
@@ -106,7 +106,7 @@ export function Upgrades() {
         {selectedUnit.size > 1 && !isSkirmish && <FormGroup className="px-4 pt-2 is-flex-direction-row is-align-items-center">
           <FormControlLabel control={
             <Checkbox checked={selectedUnit.combined} onClick={() => toggleCombined()
-            } />} label="Combined Unit" className="mr-2" />
+            } disabled={(selectedUnit.combined && !selectedUnit.joinToUnit && Mobile)} />} label="Combined Unit" className="mr-2" />
           <CustomTooltip title={"When preparing your army you may merge units by deploying two copies of the same unit as a single big unit, as long as any upgrades that are applied to all models are bought for both."} arrow enterTouchDelay={0} leaveTouchDelay={5000}>
             <InfoOutlinedIcon color="primary" />
           </CustomTooltip>

--- a/views/upgrades/Upgrades.tsx
+++ b/views/upgrades/Upgrades.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControlLabel, FormGroup, Paper, FormControl, MenuItem, InputLabel, Select } from '@mui/material';
+import { Checkbox, FormControlLabel, FormGroup, Paper, FormControl, MenuItem, InputLabel, Select, Hidden } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../data/store';
 import styles from "../../styles/Upgrades.module.css";
@@ -13,6 +13,7 @@ import SpellsTable from '../SpellsTable';
 import { CustomTooltip } from '../components/CustomTooltip';
 import UpgradeService from '../../services/UpgradeService';
 import LinkIcon from '@mui/icons-material/Link';
+import UpgradePanelHeader from "../components/UpgradePanelHeader";
 
 export function Upgrades() {
 
@@ -23,6 +24,9 @@ export function Upgrades() {
   const dispatch = useDispatch();
 
   const selectedUnit = UnitService.getSelected(list);
+
+  // if I'm gonna be empty, just stop.
+  if (!selectedUnit) return null
 
   const getUpgradeSet = (id) => army.upgradePackages.filter((s) => s.uid === id)[0];
 
@@ -90,10 +94,14 @@ export function Upgrades() {
     .filter(u => u.size > 1 && !(u.combined && !u.joinToUnit))
     .filter(u => unitsWithAttachedHeroes.indexOf(u.selectionId) === -1 || u.selectionId == selectedUnit?.joinToUnit);
 
-  return (
-    <div className={styles["upgrade-panel"]}>
+  
 
+  return (
+    <div style={{flex: "column", height: "calc(100% - 56px)", overflowY: "scroll"}}>
+
+      {/* Joining Options and Base Equipment */}
       {selectedUnit && <Paper square elevation={0}>
+
         {/* Combine unit */}
         {selectedUnit.size > 1 && !isSkirmish && <FormGroup className="px-4 pt-2 is-flex-direction-row is-align-items-center">
           <FormControlLabel control={
@@ -119,6 +127,7 @@ export function Upgrades() {
             </Select>
           </FormControl>
         </FormGroup>}
+
         {/* Equipment */}
         <div className="px-4 pt-2">
           <UnitEquipmentTable unit={selectedUnit} />
@@ -135,6 +144,10 @@ export function Upgrades() {
 
       </Paper>}
 
+
+      
+      {/* Upgrades */}
+      <div>
       {upgradeSets.map((pkg: IUpgradePackage) => (
         <div key={pkg.uid}>
           {/* <p className="px-2">{set.id}</p> */}
@@ -155,6 +168,7 @@ export function Upgrades() {
           ))}
         </div>
       ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Enabled per-unit expansion of main list in compact view; made scrolling/header behaviour consistent across each column; fixed debounce on custom naming. Restructured list page, trimmed unnecessary scrollbars off of app body (yep, go look 😛)

Advise checking out the preview build. Don't think breaks anything, but some global css changes so cautious is nice?