### PR TITLE
header of mainlist (showing list name and pts) now sticky

### DIFF
--- a/styles/Upgrades.module.css
+++ b/styles/Upgrades.module.css
@@ -1,4 +1,8 @@
 .upgrade-panel {
   background-color: #fafafa;
+  /*min-height: 100%;*/
+}
+.upgrade-panel-mobile {
+  background-color: #fafafa;
   min-height: 100%;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -43,6 +43,14 @@ a {
   transform: scale(1.02);
 }
 
+.sticky {
+  position: sticky;
+  top: 0;
+  background-color: #FAFAFA;
+  z-index: 10;
+  box-shadow: 0px 3px 5px 0px lightgrey;
+}
+
 @media print {
   body {
     zoom: 65%;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -53,7 +53,7 @@ div[role="tooltip"] {
   background-color: #FAFAFA;
   box-shadow: none !important;
 }
-.sticky.scrolled {
+.scrolled .sticky {
   z-index: 10;
   height: 68px;
   box-shadow: 0px 3px 5px 0px lightgrey !important;
@@ -62,7 +62,7 @@ div[role="tooltip"] {
   margin-bottom: -1rem;
   overflow: hidden;
 }
-.sticky.scrolled .unitName {
+.scrolled .sticky .unitName {
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -50,13 +50,14 @@ div[role="tooltip"] {
 .sticky {
   position: sticky;
   top: 0;
-  /*background-color: #FAFAFA;*/
+  background-color: #FAFAFA;
   box-shadow: none !important;
 }
 .sticky.scrolled {
   z-index: 10;
+  height: 68px;
   box-shadow: 0px 3px 5px 0px lightgrey;
-  background-color: #FAFAFA;
+  background-color: #FAFAFA !important;
   padding-bottom: 1rem;
   margin-bottom: -1rem;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -48,7 +48,6 @@ a {
   top: 0;
   background-color: #FAFAFA;
   z-index: 10;
-  box-shadow: 0px 3px 5px 0px lightgrey;
 }
 
 @media print {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -33,6 +33,10 @@ a {
   background-color: white;
 }
 
+div[role="tooltip"] {
+  z-index: 15 !important;
+}
+
 .interactable {
   cursor: pointer;
   transition: all linear 0.1s;
@@ -46,12 +50,13 @@ a {
 .sticky {
   position: sticky;
   top: 0;
-  background-color: #FAFAFA;
-  z-index: 10;
-  box-shadow: unset;
+  /*background-color: #FAFAFA;*/
+  box-shadow: none !important;
 }
 .sticky.scrolled {
+  z-index: 10;
   box-shadow: 0px 3px 5px 0px lightgrey;
+  background-color: #FAFAFA;
   padding-bottom: 1rem;
   margin-bottom: -1rem;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -48,6 +48,12 @@ a {
   top: 0;
   background-color: #FAFAFA;
   z-index: 10;
+  box-shadow: unset;
+}
+.sticky.scrolled {
+  box-shadow: 0px 3px 5px 0px lightgrey;
+  padding-bottom: 1rem;
+  margin-bottom: -1rem;
 }
 
 @media print {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -56,7 +56,7 @@ div[role="tooltip"] {
 .sticky.scrolled {
   z-index: 10;
   height: 68px;
-  box-shadow: 0px 3px 5px 0px lightgrey;
+  box-shadow: 0px 3px 5px 0px lightgrey !important;
   background-color: #FAFAFA !important;
   padding-bottom: 1rem;
   margin-bottom: -1rem;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -66,7 +66,6 @@ div[role="tooltip"] {
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  max-width: 100%;
 }
 
 @media print {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -60,6 +60,13 @@ div[role="tooltip"] {
   background-color: #FAFAFA !important;
   padding-bottom: 1rem;
   margin-bottom: -1rem;
+  overflow: hidden;
+}
+.sticky.scrolled .unitName {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 100%;
 }
 
 @media print {

--- a/views/MainList.tsx
+++ b/views/MainList.tsx
@@ -29,7 +29,7 @@ export function MainList({ onSelected, onUnitRemoved, mobile=false }) {
 
   return (
     <>
-      <div className="sticky">
+      <div id="MainListHeader" className="sticky">
         <h3 className="px-4 pt-4 is-size-4 is-hidden-mobile">{`My List - ${list.points}` + (list.pointsLimit ? `/${list.pointsLimit}` : "") + "pts"}</h3>
         <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />
       </div>

--- a/views/MainList.tsx
+++ b/views/MainList.tsx
@@ -31,8 +31,9 @@ export function MainList({ onSelected, onUnitRemoved, mobile=false }) {
     <>
       <div id="MainListHeader" className="sticky">
         <h3 className="px-4 pt-4 is-size-4 is-hidden-mobile">{`My List - ${list.points}` + (list.pointsLimit ? `/${list.pointsLimit}` : "") + "pts"}</h3>
-        <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />
       </div>
+      <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />
+      
       <ul className="mt-2">
         {
           // For each selected unit

--- a/views/MainList.tsx
+++ b/views/MainList.tsx
@@ -29,7 +29,7 @@ export function MainList({ onSelected, onUnitRemoved, mobile=false }) {
 
   return (
     <>
-      <div style={{ position: "sticky", top: 0, backgroundColor: "#FAFAFA", zIndex: 10 }}>
+      <div className="sticky">
         <h3 className="px-4 pt-4 is-size-4 is-hidden-mobile">{`My List - ${list.points}` + (list.pointsLimit ? `/${list.pointsLimit}` : "") + "pts"}</h3>
         <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />
       </div>

--- a/views/MainList.tsx
+++ b/views/MainList.tsx
@@ -29,7 +29,10 @@ export function MainList({ onSelected, onUnitRemoved, mobile=false }) {
 
   return (
     <>
-      <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />
+      <div style={{ position: "sticky", top: 0, backgroundColor: "#FAFAFA", zIndex: 10 }}>
+        <h3 className="px-4 pt-4 is-size-4 is-hidden-mobile">{`My List - ${list.points}` + (list.pointsLimit ? `/${list.pointsLimit}` : "") + "pts"}</h3>
+        <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />
+      </div>
       <ul className="mt-2">
         {
           // For each selected unit

--- a/views/MainList.tsx
+++ b/views/MainList.tsx
@@ -29,7 +29,7 @@ export function MainList({ onSelected, onUnitRemoved, mobile=false }) {
 
   return (
     <>
-      <div id="MainListHeader" className="sticky">
+      <div className="sticky">
         <h3 className="px-4 pt-4 is-size-4 is-hidden-mobile">{`My List - ${list.points}` + (list.pointsLimit ? `/${list.pointsLimit}` : "") + "pts"}</h3>
       </div>
       <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />

--- a/views/UnitSelection.tsx
+++ b/views/UnitSelection.tsx
@@ -81,10 +81,9 @@ export function UnitSelection({ onSelected }) {
           </h3>
           {army.uid == null && army.dataToolVersion !== dataToolVersion && <div className="mr-4" title="Data file may be out of date"><WarningIcon /></div>}
         </div>}
-
-        <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />
       </div>
-
+      <FullCompactToggle expanded={expandAll} onToggle={() => setExpandAll(!expandAll)} />
+      
       {
         // For each category
         Object.keys(unitGroups).map((key, i) => (

--- a/views/UnitSelection.tsx
+++ b/views/UnitSelection.tsx
@@ -74,7 +74,7 @@ export function UnitSelection({ onSelected }) {
       className={styles.menu + " menu"}
       style={{ minHeight: "100%" }}
     >
-      <div id="UnitSelectionHeader" className={isBigScreen ? "sticky" : ""}>
+      <div className={isBigScreen ? "sticky" : ""}>
         {isBigScreen && <div className="is-flex is-align-items-center">
           <h3 className="is-size-4 px-4 pt-4 is-flex-grow-1">
             {army.name} - {army.versionString}

--- a/views/UnitSelection.tsx
+++ b/views/UnitSelection.tsx
@@ -68,14 +68,13 @@ export function UnitSelection({ onSelected }) {
   };
 
   const isBigScreen = useMediaQuery({ query: '(min-width: 1024px)' });
-  const stickyHeader: any = { position: "sticky", top: 0, backgroundColor: "#FAFAFA", zIndex: 10 };
 
   return (
     <aside
       className={styles.menu + " menu"}
       style={{ minHeight: "100%" }}
     >
-      <div style={isBigScreen ? stickyHeader : null}>
+      <div className={isBigScreen ? "sticky" : ""}>
         {isBigScreen && <div className="is-flex is-align-items-center">
           <h3 className="is-size-4 px-4 pt-4 is-flex-grow-1">
             {army.name} - {army.versionString}

--- a/views/UnitSelection.tsx
+++ b/views/UnitSelection.tsx
@@ -74,7 +74,7 @@ export function UnitSelection({ onSelected }) {
       className={styles.menu + " menu"}
       style={{ minHeight: "100%" }}
     >
-      <div className={isBigScreen ? "sticky" : ""}>
+      <div id="UnitSelectionHeader" className={isBigScreen ? "sticky" : ""}>
         {isBigScreen && <div className="is-flex is-align-items-center">
           <h3 className="is-size-4 px-4 pt-4 is-flex-grow-1">
             {army.name} - {army.versionString}

--- a/views/components/UpgradePanelHeader.tsx
+++ b/views/components/UpgradePanelHeader.tsx
@@ -48,7 +48,7 @@ export default function UpgradePanelHeader() {
           onChange={e => { setCustomName(e.target.value); debounceSave(e.target.value); }}
         />
       ) : (
-        <div className="is-flex" style={{width: "100%"}}>
+        <div className="is-flex" style={{maxWidth: "calc(100% - 7rem)"}}>
           <h3 className="is-size-4 has-text-left unitName">{selectedUnit.customName || selectedUnit.name} {`[${UnitService.getSize(selectedUnit)}]`}</h3>
         </div>
       )}

--- a/views/components/UpgradePanelHeader.tsx
+++ b/views/components/UpgradePanelHeader.tsx
@@ -48,8 +48,8 @@ export default function UpgradePanelHeader() {
           onChange={e => { setCustomName(e.target.value); debounceSave(e.target.value); }}
         />
       ) : (
-        <div className="is-flex">
-          <h3 className="is-size-4 has-text-left">{selectedUnit.customName || selectedUnit.name} {`[${UnitService.getSize(selectedUnit)}]`}</h3>
+        <div className="is-flex" style={{width: "100%"}}>
+          <h3 className="is-size-4 has-text-left unitName">{selectedUnit.customName || selectedUnit.name} {`[${UnitService.getSize(selectedUnit)}]`}</h3>
         </div>
       )}
       <IconButton color="primary" className="ml-2" onClick={() => toggleEditMode()}>

--- a/views/listBuilder/DesktopView.tsx
+++ b/views/listBuilder/DesktopView.tsx
@@ -20,10 +20,9 @@ export default function DesktopView() {
 
   const columnStyle: any = { overflowY: "scroll", maxHeight: "100%" };
 
-  const setScrolled = (header, scroller) => () => {
-    let scrolled = !!document.getElementById(scroller).scrollTop;
-    let elem = document.getElementById(header);
-    if (scrolled) {
+  const setScrolled = (e) => {
+    let elem = e.target
+    if (elem.scrollTop) {
       elem.classList.add("scrolled")
     } else {
       elem.classList.remove("scrolled")
@@ -36,14 +35,14 @@ export default function DesktopView() {
         <MainMenu setListConfigurationOpen={setEditListOpen} setValidationOpen={setValidationOpen} />
       </Paper>
       <div className="columns my-0" style={{ height: "calc(100vh - 64px)" }}>
-        <div id="ColumnOne" className="column py-0 pr-0" style={columnStyle} onScroll={setScrolled("UnitSelectionHeader", "ColumnOne")}>
+        <div className="column py-0 pr-0" style={columnStyle} onScroll={setScrolled}>
           <UnitSelection onSelected={() => { }} />
         </div>
-        <div id="ColumnTwo" className="column p-0" style={columnStyle} onScroll={setScrolled("MainListHeader", "ColumnTwo")}>
+        <div className="column p-0" style={columnStyle} onScroll={setScrolled}>
           <MainList onSelected={() => { }} onUnitRemoved={() => setShowUndoRemove(true)} />
         </div>
-        <div id="ColumnThree" className="column py-0 px-0 mr-4" style={columnStyle} onScroll={setScrolled("UpgradesHeader", "ColumnThree")}>
-          <Paper id="UpgradesHeader" square className="px-4 pt-4 sticky" sx={{backgroundColor: "white"}}>
+        <div className="column py-0 px-0 mr-4" style={columnStyle} onScroll={setScrolled}>
+          <Paper square className="px-4 pt-4 sticky" sx={{backgroundColor: "white"}}>
             <UpgradePanelHeader />
           </Paper>
           <Upgrades />

--- a/views/listBuilder/DesktopView.tsx
+++ b/views/listBuilder/DesktopView.tsx
@@ -20,8 +20,14 @@ export default function DesktopView() {
 
   const columnStyle: any = { overflowY: "scroll", maxHeight: "100%" };
 
-  const setShadow = (header, scroller) => () => {
-    (document.getElementById(header).style.boxShadow = document.getElementById(scroller).scrollTop ? "0px 3px 5px 0px lightgrey" : "")
+  const setScrolled = (header, scroller) => () => {
+    let scrolled = !!document.getElementById(scroller).scrollTop;
+    let elem = document.getElementById(header);
+    if (scrolled) {
+      elem.classList.add("scrolled")
+    } else {
+      elem.classList.remove("scrolled")
+    }
   }
 
   return (
@@ -30,14 +36,14 @@ export default function DesktopView() {
         <MainMenu setListConfigurationOpen={setEditListOpen} setValidationOpen={setValidationOpen} />
       </Paper>
       <div className="columns my-0" style={{ height: "calc(100vh - 64px)" }}>
-        <div id="ColumnOne" className="column py-0 pr-0" style={columnStyle} onScroll={setShadow("UnitSelectionHeader", "ColumnOne")}>
+        <div id="ColumnOne" className="column py-0 pr-0" style={columnStyle} onScroll={setScrolled("UnitSelectionHeader", "ColumnOne")}>
           <UnitSelection onSelected={() => { }} />
         </div>
-        <div id="ColumnTwo" className="column p-0" style={columnStyle} onScroll={setShadow("MainListHeader", "ColumnTwo")}>
+        <div id="ColumnTwo" className="column p-0" style={columnStyle} onScroll={setScrolled("MainListHeader", "ColumnTwo")}>
           <MainList onSelected={() => { }} onUnitRemoved={() => setShowUndoRemove(true)} />
         </div>
-        <div id="ColumnThree" className="column py-0 px-0 mr-4" style={columnStyle} onScroll={setShadow("UpgradesHeader", "ColumnThree")}>
-          <Paper id="UpgradesHeader" square className="px-4 pt-4" sx={{position: "sticky", top: 0, backgroundColor: "white", boxShadow: "unset", zIndex: 10}}>
+        <div id="ColumnThree" className="column py-0 px-0 mr-4" style={columnStyle} onScroll={setScrolled("UpgradesHeader", "ColumnThree")}>
+          <Paper id="UpgradesHeader" square className="px-4 pt-4 sticky" sx={{backgroundColor: "white"}}>
             <UpgradePanelHeader />
           </Paper>
           <Upgrades />

--- a/views/listBuilder/DesktopView.tsx
+++ b/views/listBuilder/DesktopView.tsx
@@ -30,7 +30,6 @@ export default function DesktopView() {
           <UnitSelection onSelected={() => { }} />
         </div>
         <div className="column p-0" style={columnStyle}>
-          <h3 className="px-4 pt-4 is-size-4 is-hidden-mobile">{`My List - ${list.points}` + (list.pointsLimit ? `/${list.pointsLimit}` : "") + "pts"}</h3>
           <MainList onSelected={() => { }} onUnitRemoved={() => setShowUndoRemove(true)} />
         </div>
         <div className="column py-0 px-0 mr-4" style={columnStyle}>

--- a/views/listBuilder/DesktopView.tsx
+++ b/views/listBuilder/DesktopView.tsx
@@ -36,8 +36,8 @@ export default function DesktopView() {
         <div id="ColumnTwo" className="column p-0" style={columnStyle} onScroll={setShadow("MainListHeader", "ColumnTwo")}>
           <MainList onSelected={() => { }} onUnitRemoved={() => setShowUndoRemove(true)} />
         </div>
-        <div className="column py-0 px-0 mr-4" style={columnStyle}>
-          <Paper square className="px-4 pt-4">
+        <div id="ColumnThree" className="column py-0 px-0 mr-4" style={columnStyle} onScroll={setShadow("UpgradesHeader", "ColumnThree")}>
+          <Paper id="UpgradesHeader" square className="px-4 pt-4" sx={{position: "sticky", top: 0, backgroundColor: "white", boxShadow: "unset", zIndex: 10}}>
             <UpgradePanelHeader />
           </Paper>
           <Upgrades />

--- a/views/listBuilder/DesktopView.tsx
+++ b/views/listBuilder/DesktopView.tsx
@@ -20,16 +20,20 @@ export default function DesktopView() {
 
   const columnStyle: any = { overflowY: "scroll", maxHeight: "100%" };
 
+  const setShadow = (header, scroller) => () => {
+    (document.getElementById(header).style.boxShadow = document.getElementById(scroller).scrollTop ? "0px 3px 5px 0px lightgrey" : "")
+  }
+
   return (
     <>
       <Paper elevation={1} color="primary" square>
         <MainMenu setListConfigurationOpen={setEditListOpen} setValidationOpen={setValidationOpen} />
       </Paper>
       <div className="columns my-0" style={{ height: "calc(100vh - 64px)" }}>
-        <div className="column py-0 pr-0" style={columnStyle}>
+        <div id="ColumnOne" className="column py-0 pr-0" style={columnStyle} onScroll={setShadow("UnitSelectionHeader", "ColumnOne")}>
           <UnitSelection onSelected={() => { }} />
         </div>
-        <div className="column p-0" style={columnStyle}>
+        <div id="ColumnTwo" className="column p-0" style={columnStyle} onScroll={setShadow("MainListHeader", "ColumnTwo")}>
           <MainList onSelected={() => { }} onUnitRemoved={() => setShowUndoRemove(true)} />
         </div>
         <div className="column py-0 px-0 mr-4" style={columnStyle}>

--- a/views/listBuilder/MobileView.tsx
+++ b/views/listBuilder/MobileView.tsx
@@ -113,7 +113,7 @@ export default function MobileView() {
           maxHeight * 0.9
         ]}
         header={<UpgradePanelHeader />}>
-        <Upgrades />
+        <Upgrades mobile />
       </BottomSheet>
 
       <ValidationErrors

--- a/views/upgrades/Upgrades.tsx
+++ b/views/upgrades/Upgrades.tsx
@@ -91,7 +91,7 @@ export function Upgrades({mobile = false}) {
     .filter(u => unitsWithAttachedHeroes.indexOf(u.selectionId) === -1 || u.selectionId == selectedUnit?.joinToUnit);
 
   return (
-    <div className={mobile ? styles["upgrade-panel"] : styles["upgrade-panel-mobile"]}>
+    <div className={mobile ? styles["upgrade-panel-mobile"] : styles["upgrade-panel"]}>
 
       {selectedUnit && <Paper square elevation={0}>
         {/* Combine unit */}

--- a/views/upgrades/Upgrades.tsx
+++ b/views/upgrades/Upgrades.tsx
@@ -14,7 +14,7 @@ import { CustomTooltip } from '../components/CustomTooltip';
 import UpgradeService from '../../services/UpgradeService';
 import LinkIcon from '@mui/icons-material/Link';
 
-export function Upgrades() {
+export function Upgrades({mobile = false}) {
 
   const list = useSelector((state: RootState) => state.list);
   const gameSystem = useSelector((state: RootState) => state.army.gameSystem);
@@ -91,7 +91,7 @@ export function Upgrades() {
     .filter(u => unitsWithAttachedHeroes.indexOf(u.selectionId) === -1 || u.selectionId == selectedUnit?.joinToUnit);
 
   return (
-    <div className={styles["upgrade-panel"]}>
+    <div className={mobile ? styles["upgrade-panel"] : styles["upgrade-panel-mobile"]}>
 
       {selectedUnit && <Paper square elevation={0}>
         {/* Combine unit */}


### PR DESCRIPTION
Moved the header from the desktopview  component to the mainlist component where it can be combined as a stickyheader with the collapse-all button. Made this header sticky like the UnitSelection header.

![stickyhead](https://user-images.githubusercontent.com/23005404/140976135-d99b9916-9dc2-4979-bc7c-9e03284b371d.png)
