### PR TITLE
Updated unit count validations

### DIFF
--- a/services/ValidationService.ts
+++ b/services/ValidationService.ts
@@ -17,14 +17,14 @@ export default class ValidationService {
 
     if (army.gameSystem === "gf") {
 
-      const unitCount = list.units.filter(u => !(u.combined && (!u.joinToUnit))).length;
+      const unitCount = list.units.filter(u => !u.joinToUnit).length;
       const heroCount = list.units.filter(u => u.specialRules.findIndex(rule => rule.name === "Hero") >= 0).length;
 
       if (heroCount > Math.floor(points / 500))
         errors.push(`Max 1 hero per full 500pts.`);
       if (unitCount > Math.floor(points / 200))
-        errors.push(`Max 1 unit per full 200pts (combined units count as just 1 unit).`); // should Heroes joined to other units count as 'combined' too or not?
-      if (list.units.some(u => u.combined && u.size === 2))
+        errors.push(`Max 1 unit per full 200pts (combined units count as just 1 unit).`);
+      if (list.units.some(u => u.combined && u.size === 1))
         errors.push(`Cannot combine units of unit size [1].`);
       if (Object.values(_.groupBy(list.units.filter(u => !(u.combined && (!u.joinToUnit))), u => u.name)).some((grp: any[]) => grp.length > 3))
         errors.push(`Cannot have more than 3 copies of a particular unit.`); // combined units still count as one


### PR DESCRIPTION
Heroes joined to units equals 1 total unit. Combined unit size validation no longer uses old logic.

Closes #230 and #231 