### PR TITLE
removed upgrade sections that aren't correctly fetched

### DIFF
--- a/services/DataService.ts
+++ b/services/DataService.ts
@@ -91,7 +91,7 @@ export default class DataService {
                 // Group same items back together and sum the count
                 gains: Object.values(gainsGroups).map((grp: any[]) => {
                   const count = grp.reduce((c, next) => c + (next.count || 1), 0);
-                  console.log(grp[0].label + " " + count, grp);
+                  //console.log(grp[0].label + " " + count, grp);
                   return {
                     ...grp[0],
                     count: count
@@ -124,9 +124,9 @@ export default class DataService {
           }
         }),
         disabledUpgradeSections: (() => {
-          const sections: { id: string, options: { gains: { name: string } }[], replaceWhat: string[] }[] = u.upgrades
+          const sections: { id: string, options: { gains: { name: string } }[], replaceWhat: string[] }[] = _.compact(u.upgrades
             // Map all upgrade packages
-            .map(uid => upgradePackages.find(pkg => pkg.uid === uid))
+            .map(uid => upgradePackages.find(pkg => pkg.uid === uid)))
             // Flatten down to array of all upgrade sections
             .reduce((sections, next) => sections.concat(next.sections), []);
 

--- a/views/ListConfigurationDialog.tsx
+++ b/views/ListConfigurationDialog.tsx
@@ -72,7 +72,7 @@ export default function ListConfigurationDialog({ isEdit, open, setOpen, customA
         dispatch(loadArmyData(afData));
 
         finish({ ...childArmy, data: afData });
-      });
+      }, err => {throw(err)});
 
     } else {
       finish(army);


### PR DESCRIPTION
Wormhole Daemons of varying flavours weren't loading because some of their upgrades weren't being correctly fetched from the WebCompanion API.  They're still not, but this is no longer fatal - 'undefined' upgrade sections are now stripped out of the list before it is passed on.