### PR TITLE
fix #183 - ignore missing gameSystem in load file list

### DIFF
--- a/pages/load.tsx
+++ b/pages/load.tsx
@@ -130,7 +130,7 @@ export default function Load() {
                     const points = save.listPoints;
                     const title = (
                       <>
-                        <span style={{ fontWeight: 600 }}>{save.gameSystem.toUpperCase()} - {save.list.name}</span>
+                        <span style={{ fontWeight: 600 }}>{save.gameSystem?.toUpperCase()} - {save.list.name}</span>
                         <span style={{ color: "#656565" }}> • {points}pts</span>
                       </>
                     );


### PR DESCRIPTION
Saves not loadable because subfaction data files aren't tagged with a gameSystem, relying on their 'factionName' to infer that. I feel the real fix here is for the WebCompanion to apply gameSystem on subfaction army data, but this PR bandages things on our end by ignoring missing gameSystem from save files.

Addresses #183 