### PR TITLE
Fixed some parsing misses

### DIFF
--- a/services/DataParsingService.test.ts
+++ b/services/DataParsingService.test.ts
@@ -14,14 +14,14 @@ Upgrade with any:
 
 test("Parse 'Upgrade with:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade with:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade"
   });
 });
 
 test("Parse 'Upgrade with one:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade with one:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 1
   });
@@ -29,7 +29,7 @@ test("Parse 'Upgrade with one:'", () => {
 
 test("Parse 'Upgrade with any:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade with any:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: "any"
   });
@@ -37,8 +37,8 @@ test("Parse 'Upgrade with any:'", () => {
 
 test("Parse 'Upgrade with up to 2:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade with up to 2:");
-  console.log(upgrade);
-  expect(upgrade).toStrictEqual({
+  //console.log(upgrade);
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 2
   });
@@ -46,8 +46,8 @@ test("Parse 'Upgrade with up to 2:'", () => {
 
 test("Parse 'Upgrade with up to two:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade with up to two:");
-  console.log(upgrade);
-  expect(upgrade).toStrictEqual({
+  //console.log(upgrade);
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 2
   });
@@ -55,7 +55,7 @@ test("Parse 'Upgrade with up to two:'", () => {
 
 test("Parse 'Upgrade all models with:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade all models with:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: "all",
     model: true
@@ -64,7 +64,7 @@ test("Parse 'Upgrade all models with:'", () => {
 
 test("Parse 'Upgrade any model with one:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade any model with one:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: "any",
     select: 1,
@@ -74,7 +74,7 @@ test("Parse 'Upgrade any model with one:'", () => {
 
 test("Parse 'Upgrade all models with any:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade all models with any:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: "all",
     select: "any",
@@ -84,7 +84,7 @@ test("Parse 'Upgrade all models with any:'", () => {
 
 test("Parse 'Upgrade one model with:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade one model with:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: 1,
     model: true
@@ -93,7 +93,7 @@ test("Parse 'Upgrade one model with:'", () => {
 
 test("Parse 'Upgrade one model with one:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade one model with one:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: 1,
     select: 1,
@@ -103,7 +103,7 @@ test("Parse 'Upgrade one model with one:'", () => {
 
 test("Parse 'Upgrade one model with any:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade one model with any:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: 1,
     select: "any",
@@ -113,7 +113,7 @@ test("Parse 'Upgrade one model with any:'", () => {
 
 test("Parse 'Upgrade any model with:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade any model with:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: "any",
     model: true
@@ -122,7 +122,7 @@ test("Parse 'Upgrade any model with:'", () => {
 
 test("Parse 'Upgrade any model with one:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade any model with one:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: "any",
     select: 1,
@@ -132,7 +132,7 @@ test("Parse 'Upgrade any model with one:'", () => {
 
 test("Parse 'Upgrade any model with any:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade any model with any:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: "any",
     select: "any",
@@ -142,7 +142,7 @@ test("Parse 'Upgrade any model with any:'", () => {
 
 test("Parse 'Upgrade any model with up to two:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade any model with up to two:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: "any",
     select: 2,
@@ -150,9 +150,19 @@ test("Parse 'Upgrade any model with up to two:'", () => {
   });
 });
 
+test("Parse 'Upgrade all weapons with one:'", () => {
+  const upgrade = DataParsingService.parseUpgradeText("Upgrade all weapons with one:");
+  expect(upgrade).toMatchObject({
+    type: "upgrade",
+    select: 1,
+    affects: "all",
+    replaceWhat: ["weapons"]
+  });
+});
+
 test("Parse 'Upgrade all [weapons] with one:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade all Crossbows with one:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 1,
     affects: "all",
@@ -160,9 +170,18 @@ test("Parse 'Upgrade all [weapons] with one:'", () => {
   });
 });
 
+test("Parse 'Upgrade all weapons with:'", () => {
+  const upgrade = DataParsingService.parseUpgradeText("Upgrade all weapons with:");
+  expect(upgrade).toMatchObject({
+    type: "upgrade",
+    affects: "all",
+    replaceWhat: ["weapons"]
+  });
+});
+
 test("Parse 'Upgrade all [weapons] with:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade all Heavy Rifles with:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: "all",
     replaceWhat: ["Heavy Rifles"]
@@ -171,7 +190,7 @@ test("Parse 'Upgrade all [weapons] with:'", () => {
 
 test("Parse 'Upgrade any [weapons] with one:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade any Heavy Rifle with one:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: "any",
     select: 1,
@@ -181,7 +200,7 @@ test("Parse 'Upgrade any [weapons] with one:'", () => {
 
 test("Parse 'Upgrade any [weapons] with:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade any Heavy Rifle with:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     affects: "any",
     replaceWhat: ["Heavy Rifle"]
@@ -190,7 +209,7 @@ test("Parse 'Upgrade any [weapons] with:'", () => {
 
 test("Parse 'Upgrade up to two models with:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade up to two models with:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 2,
     model: true
@@ -203,7 +222,7 @@ test("Parse 'Upgrade up to two models with:'", () => {
 
 test("Parse 'Take one [weapon] attachment:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Take one Heavy Rifle attachment:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 1,
     attachment: true,
@@ -213,7 +232,7 @@ test("Parse 'Take one [weapon] attachment:'", () => {
 
 test("Parse 'Add one model:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Add one model:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 1,
     attachModel: true
@@ -222,7 +241,7 @@ test("Parse 'Add one model:'", () => {
 
 test("Parse 'Add one model with:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Add one model with:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 1,
     attachModel: true
@@ -231,7 +250,7 @@ test("Parse 'Add one model with:'", () => {
 
 test("Parse 'One model may take one [weapon] attachment:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("One model may take one Heavy Rifle attachment:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 1,
     affects: 1,
@@ -243,7 +262,7 @@ test("Parse 'One model may take one [weapon] attachment:'", () => {
 
 test("Parse 'Any model may take one [weapon] attachment:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Any model may take one Heavy Rifle attachment:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 1,
     affects: "any",
@@ -259,7 +278,7 @@ test("Parse 'Any model may take one [weapon] attachment:'", () => {
 
 test("Parse 'Replace [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace Gauss Rifle:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     replaceWhat: ["Gauss Rifle"]
   });
@@ -267,7 +286,7 @@ test("Parse 'Replace [weapon]:'", () => {
 
 test("Parse 'Replace one [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace one CCW:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     affects: 1,
     replaceWhat: ["CCW"]
@@ -276,7 +295,7 @@ test("Parse 'Replace one [weapon]:'", () => {
 
 test("Parse 'Replace 2x [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace 2x Armblades:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     affects: 2,
     replaceWhat: ["Armblades"]
@@ -285,7 +304,7 @@ test("Parse 'Replace 2x [weapon]:'", () => {
 
 test("Parse 'Replace 2x [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace 2x Walker Fists:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     affects: 2,
     replaceWhat: ["Walker Fists"]
@@ -294,7 +313,7 @@ test("Parse 'Replace 2x [weapon]:'", () => {
 
 test("Parse 'Replace any [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace any Assault Rifle:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     affects: "any",
     replaceWhat: ["Assault Rifle"]
@@ -303,7 +322,7 @@ test("Parse 'Replace any [weapon]:'", () => {
 
 test("Parse 'Replace all [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace all Assault Rifles:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     affects: "all",
     replaceWhat: ["Assault Rifles"]
@@ -312,7 +331,7 @@ test("Parse 'Replace all [weapon]:'", () => {
 
 test("Parse 'Replace up to two [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace up to two Assault Rifles:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     select: 2,
     replaceWhat: ["Assault Rifles"]
@@ -321,7 +340,7 @@ test("Parse 'Replace up to two [weapon]:'", () => {
 
 test("Parse 'Replace up to three [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace up to three Assault Rifles:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     select: 3,
     replaceWhat: ["Assault Rifles"]
@@ -330,7 +349,7 @@ test("Parse 'Replace up to three [weapon]:'", () => {
 
 test("Parse 'Replace [weapon] and [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace Pistol and CCW:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     replaceWhat: ["Pistol", "CCW"]
   });
@@ -338,7 +357,7 @@ test("Parse 'Replace [weapon] and [weapon]:'", () => {
 
 test("Parse 'Replace one [weapon] and [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace one Pistol and CCW:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     affects: 1,
     replaceWhat: ["Pistol", "CCW"]
@@ -347,7 +366,7 @@ test("Parse 'Replace one [weapon] and [weapon]:'", () => {
 
 test("Parse 'Replace any [weapon] and [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace any Pistol and CCW:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     affects: "any",
     replaceWhat: ["Pistol", "CCW"]
@@ -356,7 +375,7 @@ test("Parse 'Replace any [weapon] and [weapon]:'", () => {
 
 test("Parse 'Replace all [weapon] and [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace all Pistols and CCWs:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     affects: "all",
     replaceWhat: ["Pistols", "CCWs"]
@@ -365,7 +384,7 @@ test("Parse 'Replace all [weapon] and [weapon]:'", () => {
 
 test("Parse 'Replace up to two [weapon] and [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace up to two Pistols and CCWs:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     select: 2,
     replaceWhat: ["Pistols", "CCWs"]
@@ -374,7 +393,7 @@ test("Parse 'Replace up to two [weapon] and [weapon]:'", () => {
 
 test("Parse 'Any model may replace one Razor Claws:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("any model may replace one Razor Claws:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     affects: "any",
     select: 1,
@@ -386,7 +405,7 @@ test("Parse 'Any model may replace one Razor Claws:'", () => {
 
 test("Parse 'Replace [weapon], [weapon] and [weapon]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace Spear-Rifle, Spear and 2x Destroyers:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     replaceWhat: ["Spear-Rifle", "Spear", "2x Destroyers"]
   });
@@ -394,7 +413,7 @@ test("Parse 'Replace [weapon], [weapon] and [weapon]:'", () => {
 
 test("Parse 'Replace any [weapon1] and [weapon2] / [weapon3] and [weapon4]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Replace one R-Carbine and CCW / G-Rifle and CCW:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "replace",
     affects: 1,
     replaceWhat: [
@@ -410,7 +429,7 @@ test("Parse 'Replace any [weapon1] and [weapon2] / [weapon3] and [weapon4]:'", (
 
 test("Parse 'Upgrade [rule]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Upgrade Psychic(1):");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgradeRule",
     replaceWhat: ["Psychic(1)"]
   });
@@ -422,7 +441,7 @@ test("Parse 'Upgrade [rule]:'", () => {
 
 test("Parse 'Take one [equipment]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Take one Carbine attachment:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 1,
     attachment: true,
@@ -435,7 +454,7 @@ test("Parse 'Take one [equipment]:'", () => {
 // No examples of this?
 test("Parse 'Take 1 [equipment]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Take 1 Carbine attachment:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 1,
     attachment: true,
@@ -448,7 +467,7 @@ test("Parse 'Take 1 [equipment]:'", () => {
 // No examples of this?
 test("Parse 'Take any [equipment]:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Take any Carbine attachments:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: "any",
     attachment: true,
@@ -461,7 +480,7 @@ test("Parse 'Take any [equipment]:'", () => {
 // No examples of this?
 test("Parse 'Mount on:'", () => {
   const upgrade = DataParsingService.parseUpgradeText("Mount on:");
-  expect(upgrade).toStrictEqual({
+  expect(upgrade).toMatchObject({
     type: "upgrade",
     select: 1
   });

--- a/services/DataService.ts
+++ b/services/DataService.ts
@@ -4,6 +4,7 @@ import DataParsingService from "./DataParsingService";
 import { groupBy } from "./Helpers";
 import router from "next/router";
 import _ from "lodash";
+import pluralise from "pluralize";
 import styleFunctionSx from "@mui/system/styleFunctionSx";
 import EquipmentService from "./EquipmentService";
 
@@ -142,8 +143,11 @@ export default class DataService {
           for (let section of sections.filter(s => s.replaceWhat)) {
             for (let what of section.replaceWhat) {
 
+              // Are we just upgrading generic terms?
+              if (EquipmentService.GenericTerms.includes(pluralise.singular(what))) continue
+
               // Does equipment contain this thing?
-              const equipmentMatch = u.equipment.find(e => EquipmentService.compareEquipmentNames(e.name ?? e.label, what));
+              const equipmentMatch = u.equipment.some(e => EquipmentService.compareEquipmentNames(e.name ?? e.label.replace(countRegex, ""), what));
               // If equipment, then we won't be disabling this section...
               if (equipmentMatch)
                 continue;

--- a/services/EquipmentService.test.ts
+++ b/services/EquipmentService.test.ts
@@ -31,8 +31,8 @@ test("Item string parts", () => {
   } as any, 1);
 
   expect(parts2).toStrictEqual({
-    name: "Light Shields",
-    rules: ""
+    name: "Shield Bash",
+    rules: "A2"
   });
 });
 
@@ -63,5 +63,51 @@ test("String parts for weapon platform", () => {
   var input = 'Gun Platform (Star Cannon (36”, A2, AP(2))) +20pts';
   var upgrade = DataParsingService.parseEquipment(input, true);
   var parts = EquipmentService.getStringParts(upgrade, 1);
-  expect(parts).toStrictEqual({});
+  expect(parts).not.toStrictEqual({});
 })
+
+//#region compareEquipmentNames
+
+test("Positive: [Weapon] matches [Weapon]", () => {
+  const hasWhat = "Rifle"
+  const replaceWhat = "Rifle"
+  const match = EquipmentService.compareEquipmentNames(hasWhat, replaceWhat)
+  expect (match).toBe(true)
+})
+
+test("Negative: [OtherWeapon] does NOT match [weapon]", () => {
+  const hasWhat = "Rifle"
+  const replaceWhat = "Carbine"
+  const match = EquipmentService.compareEquipmentNames(hasWhat, replaceWhat)
+  expect (match).toBe(false)
+})
+
+test("Generic: 'weapon' matches [weapon]", () => {
+  const hasWhat = "Rifle"
+  const replaceWhat = "weapon"
+  const match = EquipmentService.compareEquipmentNames(hasWhat, replaceWhat)
+  expect (match).toBe(true)
+})
+
+test("Case: [Weapon] matches [weapon]", () => {
+  const hasWhat = "Rifle"
+  const replaceWhat = "rifle"
+  const match = EquipmentService.compareEquipmentNames(hasWhat, replaceWhat)
+  expect (match).toBe(true)
+})
+
+test("Plural: [Weapon] matches [Weapons]", () => {
+  const hasWhat = "Rifle"
+  const replaceWhat = "Rifles"
+  const match = EquipmentService.compareEquipmentNames(hasWhat, replaceWhat)
+  expect (match).toBe(true)
+})
+
+test("Case and Plural: [Weapon] matches [weapons]", () => {
+  const hasWhat = "Rifle"
+  const replaceWhat = "rifles"
+  const match = EquipmentService.compareEquipmentNames(hasWhat, replaceWhat)
+  expect (match).toBe(true)
+})
+
+//#endregion

--- a/services/EquipmentService.ts
+++ b/services/EquipmentService.ts
@@ -4,7 +4,7 @@ import RulesService from "./RulesService";
 
 export default class EquipmentService {
 
-  public static GenericTerms = ["weapon", "equipment", "gun", "model"]
+  public static GenericTerms = ["weapon", "equipment", "model"]
 
   public static compareEquipmentNames(hasItem: string, searchItem: string): boolean {
     let find = searchItem.toLowerCase()

--- a/services/EquipmentService.ts
+++ b/services/EquipmentService.ts
@@ -4,7 +4,11 @@ import RulesService from "./RulesService";
 
 export default class EquipmentService {
 
+  public static GenericTerms = ["weapon", "equipment", "gun", "model"]
+
   public static compareEquipmentNames(a: string, b: string): boolean {
+    // generic terms that match to any equipment
+    if (this.GenericTerms.includes(pluralise.singular(b))) return true
     //return pluralise.singular(a).indexOf(pluralise.singular(b)) > -1;
     return pluralise.singular(a || "") === pluralise.singular(b || "");
   }

--- a/services/EquipmentService.ts
+++ b/services/EquipmentService.ts
@@ -6,11 +6,12 @@ export default class EquipmentService {
 
   public static GenericTerms = ["weapon", "equipment", "gun", "model"]
 
-  public static compareEquipmentNames(a: string, b: string): boolean {
-    // generic terms that match to any equipment
-    if (this.GenericTerms.includes(pluralise.singular(b))) return true
+  public static compareEquipmentNames(hasItem: string, searchItem: string): boolean {
+    let find = searchItem.toLowerCase()
+    // generic terms that match to any equipment (so long as there is any equipment)
+    if (this.GenericTerms.includes(pluralise.singular(find))) return !!hasItem
     //return pluralise.singular(a).indexOf(pluralise.singular(b)) > -1;
-    return pluralise.singular(a || "") === pluralise.singular(b || "");
+    return pluralise.singular(hasItem.toLowerCase() || "") === pluralise.singular(find || "");
   }
 
   public static find(list: IUpgradeGainsWeapon[], match: string): IUpgradeGainsWeapon[] {

--- a/services/UpgradeService.test.ts
+++ b/services/UpgradeService.test.ts
@@ -1,4 +1,4 @@
-import { ISelectedUnit, IUpgrade, IUpgradeOption } from "../data/interfaces";
+import { ISelectedUnit, IUpgrade, IUpgradeGainsWeapon, IUpgradeOption } from "../data/interfaces";
 import UpgradeService from "./UpgradeService";
 import DataParsingService from "./DataParsingService";
 import { nanoid } from "nanoid";
@@ -21,6 +21,18 @@ const defaultUnit: ISelectedUnit = {
   joinToUnit: null,
   disabledUpgradeSections: []
 };
+
+const defaultWeapon: IUpgradeGainsWeapon = {
+  type: "ArmyBookWeapon",
+  attacks: 0,
+  range: 0,
+  specialRules: [],
+  id: "",
+  name: "",
+  label: "",
+  count: 0,
+  originalCount: 0
+}
 
 const defaultOption: () => IUpgradeOption = () => ({
   id: nanoid(5),
@@ -89,6 +101,7 @@ test('"Replace Any Rifle" is valid', () => {
     ...defaultUnit,
     equipment: [
       {
+        ...defaultWeapon,
         label: "Rifle",
         count: 4
       }
@@ -118,6 +131,7 @@ test('"Replace Any Rifle" is not valid', () => {
     ...defaultUnit,
     equipment: [
       {
+        ...defaultWeapon,
         label: "Rifle",
         count: 0
       }
@@ -148,6 +162,7 @@ test('"Replace all Rifles" is valid', () => {
     ...defaultUnit,
     equipment: [
       {
+        ...defaultWeapon,
         label: "Rifle",
         count: 5
       }
@@ -178,6 +193,7 @@ test('Radio is valid when another option in group is applied', () => {
     ...defaultUnit,
     equipment: [
       {
+        ...defaultWeapon,
         label: "Heavy Rifle",
         count: 0
       }
@@ -223,6 +239,7 @@ test('"Replace one Rifle" is valid, where Rifle is an upgrade', () => {
     size: 5,
     equipment: [
       {
+        ...defaultWeapon,
         label: "Gun",
         count: 4
       }
@@ -267,6 +284,7 @@ test('"Replace one Rifle" is not valid, where Rifle is an upgrade', () => {
     size: 5,
     equipment: [
       {
+        ...defaultWeapon,
         label: "Gun",
         count: 4
       }
@@ -296,6 +314,7 @@ test('"Replace up to 2 Rifles" is valid', () => {
     ...defaultUnit,
     equipment: [
       {
+        ...defaultWeapon,
         label: "Rifle",
         count: 4
       }
@@ -325,6 +344,7 @@ test('"Replace up to 2 Rifles" is not valid', () => {
     ...defaultUnit,
     equipment: [
       {
+        ...defaultWeapon,
         label: "Rifle",
         count: 3
       }
@@ -356,6 +376,7 @@ test('"Any model may replace 1 Claw" is valid', () => {
     size: 5,
     equipment: [
       {
+        ...defaultWeapon,
         label: "Claw",
         count: 9
       }
@@ -386,6 +407,7 @@ test('"Any model may replace 1 Claw" is not valid', () => {
     size: 5,
     equipment: [
       {
+        ...defaultWeapon,
         label: "Claw",
         count: 5
       }
@@ -416,6 +438,7 @@ test('"Replace one A / B" is valid', () => {
     size: 5,
     equipment: [
       {
+        ...defaultWeapon,
         label: "ARifle",
         count: 5
       }
@@ -445,6 +468,7 @@ test('"Replace any A / B" is valid', () => {
     size: 5,
     equipment: [
       {
+        ...defaultWeapon,
         label: "BRifle",
         count: 4
       }
@@ -475,6 +499,7 @@ test('"Replace any A / B" is not valid', () => {
     size: 5,
     equipment: [
       {
+        ...defaultWeapon,
         label: "BRifle",
         count: 0
       }

--- a/services/UpgradeService.ts
+++ b/services/UpgradeService.ts
@@ -99,7 +99,7 @@ export default class UpgradeService {
     // Try and find an upgrade instead
     for (let i = upgradeGains.length - 1; i >= 0; i--) {
       const gain = upgradeGains[i];
-      const isMatch = EquipmentService.compareEquipmentNames(gain.name, what);
+      const isMatch = EquipmentService.compareEquipmentNames(gain.name || gain.label, what);
 
       if (isMatch && (forRestore ? gain.count < gain.originalCount : gain.count > 0))
         return gain;
@@ -109,7 +109,7 @@ export default class UpgradeService {
         const item = gain as IUpgradeGainsItem;
         const toReplace = item
           .content
-          .filter(e => EquipmentService.compareEquipmentNames(e.name, what))[0];
+          .filter(e => EquipmentService.compareEquipmentNames(e.name || e.label, what))[0];
 
         if (toReplace && (forRestore ? toReplace.count < toReplace.originalCount : toReplace.count > 0))
           return toReplace;

--- a/services/UpgradeService.ts
+++ b/services/UpgradeService.ts
@@ -237,6 +237,8 @@ export default class UpgradeService {
     }
 
     if (upgrade.type === "upgrade") {
+      // Upgrade 'all' doesn't require there to be any; means none if that's all there is?
+      //if (upgrade.affects === "all") return true
 
       // Upgrade with 1:
       if (typeof (upgrade.select) === "number") {


### PR DESCRIPTION
"upgrade all weapons" didn't work because nothing is equipped with something called "weapon". Now matches any equipment against generic words.  "2x Burst Carbines" wasn't matching against "Burst Carbine" in DisabledUpgradeGroup check, now does (the count stripping regex was applied in the same declaration and the check was made against the original label rather than the stripped one.  I apply the regex strip to that label when checking for equipment availability).