### PR TITLE
Send state.army when creating faction lists

### DIFF
--- a/views/ListConfigurationDialog.tsx
+++ b/views/ListConfigurationDialog.tsx
@@ -71,7 +71,7 @@ export default function ListConfigurationDialog({ isEdit, open, setOpen, customA
 
         dispatch(loadArmyData(afData));
 
-        finish({ ...childArmy, data: afData });
+        finish({ ...army, ...childArmy, data: afData });
       }, err => {throw(err)});
 
     } else {


### PR DESCRIPTION
Lists from non-subfactions use the army state, and lists from subfactions use a mockup of that which is different.

I paste the mockup over the top of the army state so any missing data (like gameSystem) gets sent.

Fixes subfaction save files missing their gameSystem information.