### PR TITLE
Enhanced ArmyImage component

### DIFF
--- a/pages/files.tsx
+++ b/pages/files.tsx
@@ -255,6 +255,7 @@ export default function Files() {
                       }}
                       onClick={(e) => { e.stopPropagation(); chooseArmy(customArmy); }}>
                       <div className="is-flex is-flex-grow-1 is-align-items-center p-4">
+                        <ArmyImage className="mr-2" size="32px" name={customArmy.name} armyData={customArmy} />
                         <div className="is-flex-grow-1">
                           <p className="mb-1" style={{ fontWeight: 600 }}>{customArmy.name}</p>
                           <div className="is-flex" style={{ fontSize: "14px", color: "#666" }}>

--- a/pages/load.tsx
+++ b/pages/load.tsx
@@ -8,6 +8,7 @@ import _ from "lodash";
 import { Delete, MobiledataOffOutlined } from '@mui/icons-material';
 import PersistenceService from '../services/PersistenceService';
 import { ISaveData } from '../data/interfaces';
+import ArmyImage from '../views/components/ArmyImage';
 
 export default function Load() {
 
@@ -145,7 +146,7 @@ export default function Load() {
                       <ListItem key={save.list.creationTime} disablePadding secondaryAction={deleteButton}>
                         <ListItemButton onClick={() => loadSave(save)}>
                           <ListItemAvatar>
-                            <Avatar sx={{ bgcolor: "#CcE7Fa" }} style={{ overflow: "visible" }}>
+                            {/* <Avatar sx={{ bgcolor: "#CcE7Fa" }} style={{ overflow: "visible" }}>
                               <div className="is-flex" style={{
                                 height: "100%",
                                 width: "100%",
@@ -155,10 +156,11 @@ export default function Load() {
                                 backgroundRepeat: 'no-repeat',
                                 position: "relative", zIndex: 1
                               }}></div>
-                            </Avatar>
+                            </Avatar> */}
+                            <ArmyImage  image={save.coverImagePath} name={save.armyName} armyData={save.armyData} size={"32px"} />
                           </ListItemAvatar>
                           {/* <ArmyImage name={save.armyName} /> */}
-                          <ListItemText primary={title} secondary={"Modified " + modified.toLocaleDateString() + " " + time} />
+                          <ListItemText className="ml-2" primary={title} secondary={"Modified " + modified.toLocaleDateString() + " " + time} />
                         </ListItemButton>
                       </ListItem>
                     );

--- a/views/components/ArmyImage.tsx
+++ b/views/components/ArmyImage.tsx
@@ -4,9 +4,9 @@ import { RootState } from '../../data/store'
 const rotations = {} as any;
 
 
-export default function ArmyImage({ name }) {
-  const url = `img/gf_armies/${name}.png`
-  const army = useSelector((state: RootState) => state.army);
+export default function ArmyImage({ imageUrl = null, armyData = null, name = null,  size = "100px", ...props }) {
+  const url = imageUrl ?? `img/gf_armies/${name}.png`
+  const army = armyData ?? useSelector((state: RootState) => state.army).data;
   const [img, setImg] = useState(null)
   useEffect( () => {
     fetch(url)
@@ -19,7 +19,7 @@ export default function ArmyImage({ name }) {
           })
         } else {
           //console.log("didn't get an image, trying web.");
-          setImg(army?.data?.coverImagePath || "img/default_army.png")
+          setImg(army?.coverImagePath || "img/default_army.png")
         }
       })
      //console.log(army)
@@ -28,7 +28,7 @@ export default function ArmyImage({ name }) {
   
   
   return (
-    <div className="is-flex p-2" style={{ position: "relative", height: "100px", boxSizing: "content-box" }}>
+    <div {...props} className={`${props.className ?? ""} is-flex p-2`} style={{...props.style, position: "relative", height: size, flexBasis: size, boxSizing: "content-box" }}>
       <div style={{
         zIndex: 0,
         position: "absolute", top: 0, left: 0, right: 0, bottom: 0,
@@ -39,7 +39,7 @@ export default function ArmyImage({ name }) {
         transform: `rotate(${rotations[name] || (rotations[name] = 360 * Math.random())}deg)`
       }}></div>
       <div className="is-flex" style={{
-        height: "100px",
+        height: "100%",
         width: "100%",
         backgroundImage: `url(${img})`,
         backgroundPosition: "center",


### PR DESCRIPTION
Now takes more optional props to style and fetch image nicer.

Added one of them to custom armies in files page, and swapped one in for the Avatar component on the load page.

Relates to #236 but won't fix it alone - component now has facility to load specified image url, but save files don't list one yet. Could conceivably fetch by doing an API fetch on the save.armyId, but also no dataSourceUrl saved so is a crapshoot. Think best bet is to wait patiently for save/load updates.  Specific issue fixable by pushing an icon for each subfaction, but that's a bit inelegant.