### PR TITLE
gameSystem back button -> index

### DIFF
--- a/pages/gameSystem.tsx
+++ b/pages/gameSystem.tsx
@@ -39,7 +39,7 @@ export default function GameSystem() {
               color="inherit"
               aria-label="menu"
               sx={{ mr: 2 }}
-              onClick={() => router.back()}
+              onClick={() => router.push("/")}
             >
               <BackIcon />
             </IconButton>


### PR DESCRIPTION
Clicking the 'back' button on the gameSystem page is a history back, but this can send you 'forward' in the workflow to the files page if you clicked the 'back' button there which is a router push instead of a history back.

I change the gameSystem's back button to a router push back to the index page (i.e. back up the workflow).