### PR TITLE
Don't tease a tooltip where there is none.

### DIFF
--- a/views/components/RuleItem.tsx
+++ b/views/components/RuleItem.tsx
@@ -6,8 +6,10 @@ export default function RuleItem({ label, description }) {
   const descParts = description.split(bullet).map(part => (<p>{part}</p>));
 
   return (
+    description ?
     <CustomTooltip title={descParts} arrow enterTouchDelay={0} leaveTouchDelay={10000} onClick={e => e.stopPropagation()}>
       <span style={{ textDecoration: "underline", textDecorationStyle: "dashed", textDecorationColor: "#666", textUnderlineOffset: "4px" }}>{label}</span>
     </CustomTooltip>
+    : label
   );
 }

--- a/views/components/RuleItem.tsx
+++ b/views/components/RuleItem.tsx
@@ -5,11 +5,11 @@ export default function RuleItem({ label, description }) {
   const bullet = /•|/;
   const descParts = description.split(bullet).map(part => (<p>{part}</p>));
 
-  return (
-    description ?
+  let content = description ?
     <CustomTooltip title={descParts} arrow enterTouchDelay={0} leaveTouchDelay={10000} onClick={e => e.stopPropagation()}>
       <span style={{ textDecoration: "underline", textDecorationStyle: "dashed", textDecorationColor: "#666", textUnderlineOffset: "4px" }}>{label}</span>
     </CustomTooltip>
-    : label
-  );
+    : <span>{label}</span>
+
+  return content;
 }


### PR DESCRIPTION
Rules with no description (e.g. "Defense(+1)" no longer look like they will display one when you hover them, only to display an empty tooltip.

![Bad](https://user-images.githubusercontent.com/23005404/143903952-2c224e81-214a-4c96-a77c-c74084dadc4a.png)

![Better](https://user-images.githubusercontent.com/23005404/143903960-069cf68a-7373-4cdb-b98f-f0c3ed9f824d.png)

