### PR TITLE
Fix for Assault Walkers having only one Fist Upgrade

### DIFF
--- a/services/UpgradeService.ts
+++ b/services/UpgradeService.ts
@@ -9,7 +9,6 @@ import { nanoid } from "nanoid";
 export default class UpgradeService {
   static calculateListTotal(list: ISelectedUnit[]) {
     return list
-      .filter(u => u.selectionId !== "dummy")
       .reduce((value, current) => value + UpgradeService.calculateUnitTotal(current), 0);
   }
 
@@ -127,7 +126,7 @@ export default class UpgradeService {
     if (upgrade.type === "upgrade") {
 
       // "Upgrade any model with:"
-      if (upgrade.affects === "any" && unit?.size > 1)
+      if (upgrade.affects === "any" && (unit?.size > 1 || (upgrade.replaceWhat && upgrade.replaceWhat[0]?.length > 0)))
         return "updown";
 
       // Select > 1
@@ -174,8 +173,6 @@ export default class UpgradeService {
   }
 
   public static isValid(unit: ISelectedUnit, upgrade: IUpgrade, option: IUpgradeOption): boolean {
-    
-    //if (unit.selectionId === "dummy") return false
 
     const controlType = this.getControlType(unit, upgrade);
     //const alreadySelected = this.countApplied(unit, upgrade, option);
@@ -240,43 +237,46 @@ export default class UpgradeService {
     }
 
     if (upgrade.type === "upgrade") {
+      
       // Upgrade 'all' doesn't require there to be any; means none if that's all there is?
       //if (upgrade.affects === "all") return true
 
-      // Upgrade with 1:
+      // upgrade (n? (models|weapons)?) with...
+      var available = unit.size
+      
+      // if replacing equipment, count number of those equipment available
+      if (upgrade.replaceWhat) {
+        for (let what of upgrade.replaceWhat as string[]) {
+
+          available = unit.selectedUpgrades
+            // Take all gains from all selected upgrades
+            .reduce((gains, next) => gains.concat(next.gains), [])
+            // Add original equipment (for each model)
+            .concat(unit.equipment.map(e => {return {...e, count: e.count * unit.size}}))
+            // Take only the gains that match this dependency
+            .filter(g => EquipmentService.compareEquipmentNames(g.name, what))
+            // Count how many we have
+            .reduce((count, next) => count + next.count, 0);
+
+        }
+      }
+
+       // Upgrade [(any)?] with n:
       if (typeof (upgrade.select) === "number") {
 
         if (upgrade.affects === "any") {
 
-          if (appliedInGroup >= upgrade.select * unit.size) {
+          if (appliedInGroup >= upgrade.select * available) {
             return false;
           }
 
         } else if (appliedInGroup >= upgrade.select) {
           return false;
         }
+
         // Upgrade any
-      } else if (upgrade.affects === "any" && appliedInGroup >= unit.size) {
+      } else if (upgrade.affects === "any" && appliedInGroup >= available) {
         return false;
-      }
-
-      if (upgrade.replaceWhat) {
-        for (let what of upgrade.replaceWhat as string[]) {
-
-          const available = unit.selectedUpgrades
-            // Take all gains from all selected upgrades
-            .reduce((gains, next) => gains.concat(next.gains), [])
-            // Add original equipment
-            .concat(unit.equipment)
-            // Take only the gains that match this dependency
-            .filter(g => EquipmentService.compareEquipmentNames(g.name, what))
-            // Count how many we have
-            .reduce((count, next) => count + next.count, 0);
-
-          if (appliedInGroup >= available) {
-            return false;
-          }
-        }
       }
     }
 


### PR DESCRIPTION
'getControlType' set 'any' upgrades to updowns only if the unit size was > 1 (because it wanted to use checkboxes for size-1 units, equating 'any' with 'all' and assuming that the upgrade applied per-model). Now checks if the upgrade applies per-model before letting size-1 units go, and using updown like any other unit if the upgrade is per-equipment.

'isValid' validated 'upgrade X [things] with (up to) Y:' by checking against the unit size first, assuming 'things' meant models or that the unit size would be >= the amount of [things], and only *then* checking for the total count of [things]. Now checks if [things] is anything other than models *first*.

Fixes Assault Walkers being unable to select more than one fist upgrade.

![TexasRangers](https://user-images.githubusercontent.com/23005404/144109128-81f7622c-c967-4060-bbcc-286e64101e9e.png)

