### PR TITLE
Fix for equipment count error.

### DIFF
--- a/services/UpgradeService.ts
+++ b/services/UpgradeService.ts
@@ -252,7 +252,7 @@ export default class UpgradeService {
             // Take all gains from all selected upgrades
             .reduce((gains, next) => gains.concat(next.gains), [])
             // Add original equipment (for each model)
-            .concat(unit.equipment.map(e => {return {...e, count: e.count * unit.size}}))
+            .concat(unit.equipment)
             // Take only the gains that match this dependency
             .filter(g => EquipmentService.compareEquipment(g, what))
             // Count how many we have


### PR DESCRIPTION
No longer multiplies equipment count by unit size when validating upgrades. (Change introduced in error during Assault Walker Fist fix).

Currently some weapon upgrades can be taken too many times because of a bug. Simply fixes that bug, restoring correct behaviour.