### PR TITLE
Fix unit preview dummies counting in validation.

### DIFF
--- a/services/UpgradeService.ts
+++ b/services/UpgradeService.ts
@@ -9,6 +9,7 @@ import { nanoid } from "nanoid";
 export default class UpgradeService {
   static calculateListTotal(list: ISelectedUnit[]) {
     return list
+      .filter(u => u.selectionId !== "dummy")
       .reduce((value, current) => value + UpgradeService.calculateUnitTotal(current), 0);
   }
 

--- a/services/ValidationService.ts
+++ b/services/ValidationService.ts
@@ -17,23 +17,24 @@ export default class ValidationService {
 
     if (army.gameSystem === "gf") {
 
-      const unitCount = list.units.filter(u => !u.joinToUnit).length;
-      const heroes = list.units.filter(u => u.specialRules.some(rule => rule.name === "Hero"))
+      const units = list.units.filter(u => u.selectionId !== "dummy")
+      const unitCount = units.filter(u => !u.joinToUnit).length;
+      const heroes = units.filter(u => u.specialRules.some(rule => rule.name === "Hero"))
       const heroCount = heroes.length;
-      const joinedHeroes = heroes.filter(u => (u.joinToUnit && list.units.some(t => t.selectionId === u.joinToUnit)))
+      const joinedHeroes = heroes.filter(u => (u.joinToUnit && units.some(t => t.selectionId === u.joinToUnit)))
       const joinedIds = joinedHeroes.map(u => u.joinToUnit)
 
       if (heroCount > Math.floor(points / 500))
         errors.push(`Max 1 hero per full 500pts.`);
       if (unitCount > Math.floor(points / 200))
         errors.push(`Max 1 unit per full 200pts (combined units count as just 1 unit).`);
-      if (list.units.some(u => u.combined && u.size === 1))
+      if (units.some(u => u.combined && u.size === 1))
         errors.push(`Cannot combine units of unit size [1].`);
-      if (list.units.some(u => u.size === 1 && joinedIds.includes(u.selectionId)))
+      if (units.some(u => u.size === 1 && joinedIds.includes(u.selectionId)))
         errors.push(`Heroes cannot join units that only contain a single model.`);
       if (new Set(joinedIds).size < joinedIds.length)
         errors.push(`A unit can only have a maximum of one Hero attached.`);
-      if (Object.values(_.groupBy(list.units.filter(u => !(u.combined && (!u.joinToUnit))), u => u.name)).some((grp: any[]) => grp.length > 3))
+      if (Object.values(_.groupBy(units.filter(u => !(u.combined && (!u.joinToUnit))), u => u.name)).some((grp: any[]) => grp.length > 3))
         errors.push(`Cannot have more than 3 copies of a particular unit.`); // combined units still count as one
     }
     


### PR DESCRIPTION
Previewed units are currently counting towards lists' points totals and unit counts.

This fixes that.