### PR TITLE
Fixing "Cannot read properties of undefined (reading 'name')"

### DIFF
--- a/views/ListConfigurationDialog.tsx
+++ b/views/ListConfigurationDialog.tsx
@@ -42,9 +42,11 @@ export default function ListConfigurationDialog({ isEdit, open, setOpen, customA
   // Update default name once data comes in
   useEffect(() => {
     if (!isEdit && army.data && army.data.name) {
-      var armyName = (army.data.uid && customArmies) ? customArmies?.find(t => t.uid === army.data.uid).name : army.data.name
-      setArmyName(armyName);
-      setSelectedChild(armyName);
+      var armyName = (army.data.uid && customArmies) ? customArmies?.find(t => t.uid === army.data.uid)?.name : army.data.name
+      if(armyName) {
+        setArmyName(armyName);
+        setSelectedChild(armyName);
+      }
     }
   }, [army.data, customArmies, isEdit]);
 


### PR DESCRIPTION
Fixing "Cannot read properties of undefined (reading 'name')" Application error when switching between systems after working on an army.