### PR TITLE
Fix #338: Rules treating units 'as if' psy/wiz should not trigger the unit to actually BE a psy/wiz.

### DIFF
--- a/views/upgrades/Upgrades.tsx
+++ b/views/upgrades/Upgrades.tsx
@@ -72,7 +72,7 @@ export function Upgrades({ mobile = false }) {
       const ruleDef = ruleDefinitions.find((rd) => rd.name === r.name);
       console.log(r.name, ruleDef);
       const ruleDesc = ruleDef?.description;
-      result ||= ruleDesc && /(?:Psychic|Wizard)\(\d\)/i.test(ruleDesc);
+      result ||= ruleDesc && /(?:Psychic|Wizard)\(\d\)/i.test(ruleDesc) && !(/(?:as if)/i.test(ruleDesc));
     }
     return result;
   })();


### PR DESCRIPTION
Fixes Issue #338.

Rationale:  isPsychic() cycles through every rule for this unit and see if it includes the word Psychic(X) or Wizard(X), which is insufficient to determine whether it's actually a Psychic(X) or Wizard(X).  This rules out unit special rules that treat the unit "as if", for the purpose of spell blocking.