### PR TITLE
Image overlapping with button

### DIFF
--- a/views/listBuilder/MobileView.tsx
+++ b/views/listBuilder/MobileView.tsx
@@ -100,7 +100,7 @@ export default function MobileView() {
             <Typography variant="h5" sx={{ mb: 2 }}>
               Your list is empty
             </Typography>
-            <Button variant="outlined" onClick={() => handleSlideChange(null, 0)} sx={{ mb: 4 }}>
+            <Button variant="outlined" onClick={() => handleSlideChange(null, 0)} sx={{ mb: 4, zIndex: 2 }}>
               <Add /> Add Units
             </Button>
             <ArmyImage name={armyData?.factionName ?? armyData?.name} armyData={armyData} />


### PR DESCRIPTION
![スクリーンショット 2022-09-01 8 59 32](https://user-images.githubusercontent.com/48720021/187807048-e56ced1e-ecb1-4cda-8a36-4fe509d12ff1.png)

Some faction's image overlapped with the button in mobile view, which user can't click.

Fix: Simply increased z-index of the button to 2.