### PR TITLE
Fixed GF, GFF, AoF and AoFS campaign names and labels of injuries, talents, traits and skill sets

### DIFF
--- a/data/campaign.ts
+++ b/data/campaign.ts
@@ -158,7 +158,7 @@ const traitDefinitions = {
         "description": "Gets -1 to rolls when in melee."
       },
       {
-        "name": "Traumatised",
+        "name": "Traumatized",
         "description": "Gets -1 to rolls when taking morale tests."
       },
       {

--- a/data/campaign.ts
+++ b/data/campaign.ts
@@ -334,7 +334,7 @@ const traitDefinitions = {
         "description": "Gets -1 to rolls when in melee."
       },
       {
-        "name": "Traumatised",
+        "name": "Traumatized",
         "description": "Gets -1 to rolls when taking morale tests."
       },
       {

--- a/data/campaign.ts
+++ b/data/campaign.ts
@@ -565,7 +565,7 @@ const traitDefinitions = {
       },
       {
         "name": "Elite",
-        "description": "May re-roll one roll of any kind once per game."
+        "description": "May re-roll one die of any kind once per game."
       }
     ],
     "heroes": [
@@ -574,15 +574,15 @@ const traitDefinitions = {
         traits: [
           {
             name: "Leader",
-            description: "Friendly units within 6” get +1 to morale tests."
+            description: "Friendly units within 3” get +1 to morale tests."
           },
           {
             name: "Instigator",
-            description: "Friendly units within 6” get +1 to melee."
+            description: "Friendly units within 3” get +1 to melee."
           },
           {
             name: "Tactician",
-            description: "Friendly units within 6” get +1 to shooting."
+            description: "Friendly units within 3” get +1 to shooting."
           }
         ]
       },
@@ -591,15 +591,15 @@ const traitDefinitions = {
         traits: [
           {
             name: "Vanguard",
-            description: "Friendly units within 6” get +1 to morale tests."
+            description: "Friendly units within 3” get +4” charge range."
           },
           {
             name: "Scavenger",
-            description: "Friendly units within 6” get +1 to melee."
+            description: "Friendly units within 3” get +6” firing range."
           },
           {
             name: "Mastermind",
-            description: "Friendly units within 6” get +1 to shooting."
+            description: "Enemy units within 3” get -1 to defense."
           }
         ]
       },
@@ -608,15 +608,15 @@ const traitDefinitions = {
         traits: [
           {
             name: "Duellist",
-            description: "Friendly units within 6” get +1 to morale tests."
+            description: "Enemy units get -1 in melee against the hero."
           },
           {
             name: "Fanatic",
-            description: "Friendly units within 6” get +1 to melee."
+            description: "The hero gets +1 attack when in melee."
           },
           {
             name: "Berserker",
-            description: "Friendly units within 6” get +1 to shooting."
+            description: "Enemies get +1 to wound results when in melee with the hero."
           }
         ]
       },
@@ -649,8 +649,8 @@ const traitDefinitions = {
             description: "Enemy units further than 12” get -1 to shooting rolls against the hero."
           },
           {
-            name: "Daredevil",
-            description: "The hero ignores dangerous terrain effects."
+            name: "Climber",
+            description: "The hero needs to roll only 2+ (instead of 3+) when dropping, leaping and jumping."
           }
         ]
       },
@@ -659,15 +659,15 @@ const traitDefinitions = {
         traits: [
           {
             name: "Chemist",
-            description: "Friendly units within 6” get +1 to morale tests when in melee."
+            description: "Friendly units within 3” get -1 to wound result rolls."
           },
           {
             name: "Herbalist",
-            description: "Friendly units within 6” may ignore wounds on a roll of 6+."
+            description: "Friendly units within 3” may ignore wounds on a roll of 6+."
           },
           {
             name: "Warden",
-            description: "When the hero is activated roll one die, on a 5+ all friendly units within 6” stop being pinned."
+            description: "When the hero is activated roll one die, on a 5+ all friendly units within 3” stop being stunned."
           }
         ]
       }
@@ -686,7 +686,7 @@ const traitDefinitions = {
         "description": "Gets -1 to rolls when in melee."
       },
       {
-        "name": "Traumatised",
+        "name": "Traumatized",
         "description": "Gets -1 to rolls when taking morale tests."
       },
       {
@@ -705,7 +705,7 @@ const traitDefinitions = {
       },
       {
         "name": "Bitter Rivalry",
-        "description": "Always hits pinned units on 2+."
+        "description": "Always hits stunned units on 2+."
       },
       {
         "name": "Horrible Scars",

--- a/data/campaign.ts
+++ b/data/campaign.ts
@@ -415,15 +415,15 @@ const traitDefinitions = {
         traits: [
           {
             name: "Vanguard",
-            description: "Friendly units within 6” get +1 to morale tests."
+            description: "Friendly units within 6” get +4” charge range."
           },
           {
             name: "Scavenger",
-            description: "Friendly units within 6” get +1 to melee."
+            description: "Friendly units within 6” get +6” firing range."
           },
           {
             name: "Mastermind",
-            description: "Friendly units within 6” get +1 to shooting."
+            description: "Enemy units within 6” get -1 to defense."
           }
         ]
       },
@@ -432,15 +432,15 @@ const traitDefinitions = {
         traits: [
           {
             name: "Duellist",
-            description: "Friendly units within 6” get +1 to morale tests."
+            description: "Enemy units get -1 in melee against the hero."
           },
           {
             name: "Fanatic",
-            description: "Friendly units within 6” get +1 to melee."
+            description: "The hero gets +1 attack when in melee."
           },
           {
             name: "Berserker",
-            description: "Friendly units within 6” get +1 to shooting."
+            description: "Enemies get -1 to morale test when in melee with the hero."
           }
         ]
       },
@@ -491,7 +491,7 @@ const traitDefinitions = {
           },
           {
             name: "Warden",
-            description: "When the hero is activated roll one die, on a 5+ all friendly units within 6” stop being pinned."
+            description: "When the hero is activated roll one die, on a 5+ all friendly units within 6” stop being wavering."
           }
         ]
       }
@@ -510,7 +510,7 @@ const traitDefinitions = {
         "description": "Gets -1 to rolls when in melee."
       },
       {
-        "name": "Traumatised",
+        "name": "Traumatized",
         "description": "Gets -1 to rolls when taking morale tests."
       },
       {
@@ -529,7 +529,7 @@ const traitDefinitions = {
       },
       {
         "name": "Bitter Rivalry",
-        "description": "Always hits pinned units on 2+."
+        "description": "Always hits wavering units on 2+."
       },
       {
         "name": "Horrible Scars",


### PR DESCRIPTION
Fix for [issue 359](https://github.com/AdamLay/opr-army-forge/issues/359).

In addition, I checked also AoF, GF, and GFF campaign rules and fixed the labels and names of all injuries, talents, traits and skillsets. For GF and GFF this was just one change from British to American English. For AoF and AoFS it was fixing wrong rules texts.