### PR TITLE
Added AoFS rules alert if multiple Sergeant, Musician or Battle Standards in army

### DIFF
--- a/services/ValidationService.ts
+++ b/services/ValidationService.ts
@@ -88,6 +88,21 @@ export default class ValidationService {
         errors.push(`Heroes only join units from their own faction.`);
     }
 
+    if (army.gameSystem === "aofs") {
+
+      // Rule: When preparing your army you may only have one model with one of the following upgrades (across the entire army).
+      const sergeants = units.filter(u => u.selectedUpgrades.some(upgrade => upgrade.option.label === "Sergeant"));
+      const sergeantsCount = sergeants.length;
+      const musicians = units.filter(u => u.selectedUpgrades.some(upgrade => upgrade.option.label === "Musician"));
+      const musiciansCount = musicians.length;
+      const battleStandards = units.filter(u => u.selectedUpgrades.some(upgrade => upgrade.option.label === "Battle Standard"));
+      const battleStandrdsCount = battleStandards.length;
+  
+      if (sergeantsCount + musiciansCount + battleStandrdsCount > 1) {
+        errors.push(`Max 1 of the following upgrades per army (not one of each!): Sergeant, Musician or Battle Standard.`);
+      }
+    }
+
     if (army.loadedArmyBooks.length > 2) {
       errors.push("Players may bring units from up to two factions in the same list.")
     }


### PR DESCRIPTION
The relevant AoFS command group rule in basic rulebook v2.16 is: "When preparing your army you may only have one model with one of the following upgrades (across the entire army)."

I interpret this rule as "Exactly one model in the entire army can have Sergant exclusive-or Musician exclusive-or Battle Standard".

This rule was not reflected in the rule alerts so far, allowing users to build illegal armies with, e.g., multiple Sergeants.

The error is now shown in many cases, these examples cover most or maybe even all cases:
Example 1: any unit has more than one out of Sergeant, Musician, Battle Standard
Example 2: two units both use Sergeant (same applies for Musician/Battle Standard)
Example 3: unit A has Sergeant and unit B has Musician (i.e., two units have any combination of the three command groups)


This PR partially addresses [issue 345](https://github.com/AdamLay/opr-army-forge/issues/345). That issue is about removing the battle group upgrade when duplicating a unit. While that would be nice in the future, showing the error as implemented by me at least allows users to take note of and fix their army issue.


PS: feel free to change the error message. It's rather long, but I struggled to make it shorter without becoming more vague/unclear.