### PR TITLE
Added showing special rules for campaign upgrades in the print view

### DIFF
--- a/data/listSlice.ts
+++ b/data/listSlice.ts
@@ -303,6 +303,8 @@ export const listSlice = createSlice({
         unit.traits.push(trait);
       }
 
+      state.points = UpgradeService.calculateListTotal(state.units);
+
       debounceSave(current(state));
     },
     setUnitNotes(state, action: PayloadAction<{ unitId: string, notes: string }>) {

--- a/pages/view.tsx
+++ b/pages/view.tsx
@@ -83,7 +83,13 @@ export default function View() {
       .uniq()
       .value();
 
-    return unitRules.concat(usedWeaponRules);
+    const usedTraitsRules = _.chain(list?.units)
+      .map((unit) => unit.traits)
+      .flattenDeep()
+      .uniq()
+      .value();
+    
+    return unitRules.concat(usedWeaponRules).concat(usedTraitsRules);
   }, [list?.units]);
 
   if (!armyState.loaded) return <p>Loading...</p>;

--- a/services/UnitService.ts
+++ b/services/UnitService.ts
@@ -150,6 +150,7 @@ export default class UnitService {
             id: x.id,
             count: x.count,
           })),
+        traits: unit.traits,
       };
     };
 

--- a/services/UnitService.ts
+++ b/services/UnitService.ts
@@ -138,14 +138,18 @@ export default class UnitService {
         id: unit.id,
         customName: unit.customName,
         joinToUnit: unit.joinToUnit,
-        upgrades: unit.selectedUpgrades.map((x) => ({
-          sectionId: x.upgrade.uid,
-          optionId: x.option.id,
-        })),
-        loadout: unit.loadout.map((x) => ({
-          id: x.id,
-          count: x.count,
-        })),
+        upgrades: unit.selectedUpgrades
+          .sort((a,b) => (a.upgrade.label > b.upgrade.label) ? 1 : ((a.option.label > b.option.label) ? -1 : 0))
+          .map((x) => ({
+            sectionId: x.upgrade.uid,
+            optionId: x.option.id,
+          })),
+        loadout: unit.loadout
+          .sort((a,b) => (a.label > b.label) ? 1 : 0)
+          .map((x) => ({
+            id: x.id,
+            count: x.count,
+          })),
       };
     };
 

--- a/services/UpgradeService.tsx
+++ b/services/UpgradeService.tsx
@@ -71,7 +71,7 @@ export default class UpgradeService {
         gainEquipment.map((g) => ({
           ...g,
           count: isAffectsAll ? g.count * unit.size : g.count,
-          isModel: option.isModel // Upgrade items which are models (weapon teams...)
+          isModel: option.isModel, // Upgrade items which are models (weapon teams...)
         }))
       );
     } else if (upgrade.type === "replace") {
@@ -97,7 +97,7 @@ export default class UpgradeService {
           ...g,
           // "Replace all" is replacing each item with "g.count" copies,
           // whereas "replace 2x something" is replacing 2 with "g.count"
-          count: isAffectsAll ? g.count * removeCount : g.count
+          count: isAffectsAll ? g.count * removeCount : g.count,
         }))
       );
     }
@@ -134,18 +134,17 @@ export default class UpgradeService {
     }
 
     const isHero = unit.specialRules.some((r) => r.name === "Hero");
-    if (isHero && unit.traits && unit.traits.length > 0) {
-      
+    if (isHero && unit.traits?.length > 0) {
       const allTraitDefinitions = getTraitDefinitions();
       const injuryDefinitions = allTraitDefinitions["injuries"];
       const talentDefinitions = allTraitDefinitions["talents"];
-      
+
       const isInjury = (trait: string) => !!injuryDefinitions.find((x) => x.name === trait);
       const isTalent = (trait: string) => !!talentDefinitions.find((x) => x.name === trait);
-    
-      let traitCount = 0,
-        injuryCount = 0,
-        talentCount = 0;
+
+      let traitCount = 0;
+      let injuryCount = 0;
+      let talentCount = 0;
       for (let trait of unit.traits) {
         if (isInjury(trait)) injuryCount++;
         else if (isTalent(trait)) talentCount++;

--- a/services/UpgradeService.tsx
+++ b/services/UpgradeService.tsx
@@ -14,6 +14,7 @@ import { nanoid } from "nanoid";
 import _ from "lodash";
 import UnitService from "./UnitService";
 import { makeCopy } from "./Helpers";
+import { getTraitDefinitions, ISkillSet, ITrait } from "../data/campaign";
 
 export default class UpgradeService {
   private static readonly countRegex = /^(\d+)x\s/;
@@ -130,6 +131,28 @@ export default class UpgradeService {
       if (upgrade.cost) {
         cost += upgrade.cost;
       }
+    }
+
+    const isHero = unit.specialRules.some((r) => r.name === "Hero");
+    if (isHero && unit.traits && unit.traits.length > 0) {
+      
+      const allTraitDefinitions = getTraitDefinitions();
+      const injuryDefinitions = allTraitDefinitions["injuries"];
+      const talentDefinitions = allTraitDefinitions["talents"];
+      
+      const isInjury = (trait: string) => !!injuryDefinitions.find((x) => x.name === trait);
+      const isTalent = (trait: string) => !!talentDefinitions.find((x) => x.name === trait);
+    
+      let traitCount = 0,
+        injuryCount = 0,
+        talentCount = 0;
+      for (let trait of unit.traits) {
+        if (isInjury(trait)) injuryCount++;
+        else if (isTalent(trait)) talentCount++;
+        else traitCount++;
+      }
+
+      cost += 5 * talentCount - 5 * injuryCount;
     }
 
     const levelCost =

--- a/views/ViewCards.tsx
+++ b/views/ViewCards.tsx
@@ -215,6 +215,7 @@ export function UnitCard({
   );
 
   const traitsSection = unit.traits?.length > 0 && (
+    <Box mb={1} px={1} fontSize="14px">
     <div className="px-2 mb-4" style={{ fontSize: "14px" }}>
       {unit.traits.map((trait: string, index: number) => {
         const traitDef = traitDefinitions.find((x) => x.name === trait);
@@ -234,6 +235,7 @@ export function UnitCard({
         );
       })}
     </div>
+    </Box>
   );
 
   const joinedUnitText = attachedTo && (

--- a/views/upgrades/CampaignUpgrades.tsx
+++ b/views/upgrades/CampaignUpgrades.tsx
@@ -33,7 +33,7 @@ export default function CampaignUpgrades({ unit }: CampaignUpgradesProps) {
   const level = unit.xp ? Math.floor(unit.xp / 5) : 0;
 
   const isInjury = (trait: string) => !!injuryDefinitions.find((x) => x.name === trait);
-  const isTalent = (trait: string) => !!injuryDefinitions.find((x) => x.name === trait);
+  const isTalent = (trait: string) => !!talentDefinitions.find((x) => x.name === trait);
 
   let traitCount = 0,
     injuryCount = 0,


### PR DESCRIPTION
So far the special rules for campaign upgrades (injuries, talents, traits and skill sets) were not shown on the printout. The main commit in this PR fixes this. This fixes [issue 358](https://github.com/AdamLay/opr-army-forge/issues/358).

The other two commits fix bugs.

1) When you add injuries & talents in the unit editor, there's supposed to be a number like "Injuries [2]" behind that heading if one or more injuries/talents are selected. This worked for Injuries, but was broken for Talents. This is now fixed.

2) Campaign special rules names in the print view were not visually consistent with the other special rules, but were touching the left border. This is now fixed by putting them into the same Box-tag used for the other special rules.