### PR TITLE
#347 Campaign traits are now shown below Equipment if any are selected

### DIFF
--- a/services/TraitService.tsx
+++ b/services/TraitService.tsx
@@ -1,0 +1,53 @@
+import { getTraitDefinitions, getFlatTraitDefinitions, ITrait } from "../data/campaign";
+
+export default class TraitService {
+
+  /**
+   * Groups traits into injuries, talents and traits by checking their name against the campaign data.
+   * The output are ITrait-s to be able to use them in RuleLists.
+   * @param {string[]} traits an array of trait names
+   * @return {} a dictionary with keys "injuries", "talents" and "traits" containing ITrait[] with trait names and descriptions correctly set
+   */
+  static groupTraits(traits: string[]): { [key: string]: ITrait[] } {
+    let groupedTraits: { [key: string]: ITrait[] } = {};
+
+    if (!traits || traits.length === 0) return groupedTraits;
+
+    groupedTraits["injuries"] = [];
+    groupedTraits["talents"] = [];
+    groupedTraits["traits"] = [];
+
+    const allTraitDefinitions = getTraitDefinitions();
+    const injuryDefinitions = allTraitDefinitions["injuries"];
+    const talentDefinitions = allTraitDefinitions["talents"];
+    
+    const flatTraitDefinitions = getFlatTraitDefinitions();
+    
+    const isInjury = (trait: string) => !!injuryDefinitions.find((x) => x.name === trait);
+    const isTalent = (trait: string) => !!talentDefinitions.find((x) => x.name === trait);
+
+    // using flat trait definitions works for heroes and standard units without special handling code
+    const isTrait = (trait: string) => !!flatTraitDefinitions.find((x) => x.name === trait && !isInjury(x.name) && !isTalent(x.name));
+
+    // the dictionaries created to be returned as ITraits below are currently only used as parameter for RuleList, which ignores the id of
+    // the ITrait, thus we don't set any id this might lead to problems in other use cases
+    for (let trait of traits) {
+
+      const traitDescription = flatTraitDefinitions.find((x) => x.name === trait).description;
+
+      if (isInjury(trait)) {
+          groupedTraits["injuries"].push( { id: "", name: trait, description: traitDescription } );
+      }
+      
+      if (isTalent(trait)) {
+          groupedTraits["talents"].push( { id: "", name: trait, description: traitDescription } );
+      }
+
+      if (isTrait(trait)) {
+          groupedTraits["traits"].push( { id: "", name: trait, description: traitDescription } );
+      }
+    }
+
+    return groupedTraits;
+  }
+}

--- a/views/CampaignTraitTable.tsx
+++ b/views/CampaignTraitTable.tsx
@@ -1,0 +1,70 @@
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from "@mui/material";
+import TraitService from "../services/TraitService";
+import { ITrait }  from "../data/campaign";
+import RuleList from "./components/RuleList";
+
+interface CampaignTraitTableProps {
+  traits: string[];
+  square: boolean;
+  hideTraits?: boolean;
+}
+
+export default function CampaignTraitTable({
+  traits,
+  square,
+  hideTraits = false,
+}: CampaignTraitTableProps) {
+  const hasTraits = traits?.length > 0;
+
+  const cellStyle = {
+    px: 1,
+  };
+  const headerStyle = { ...cellStyle, fontWeight: 600, py: 0.25 };
+
+  const groupedTraits = TraitService.groupTraits(traits);
+  Object.keys(groupedTraits).forEach(key => {
+    if (groupedTraits[key].length === 0) {
+      delete groupedTraits[key];
+    }
+  });
+
+  return (
+    <>
+      {hasTraits && !hideTraits && (
+        <TableContainer component={Paper} sx={{ mt: 2 }} square={square} elevation={0}>
+          <Table size="small">
+            <TableHead>
+              <TableRow sx={{ backgroundColor: "action.hover", fontWeight: 600 }}>
+                <TableCell sx={headerStyle}>Campaign Traits</TableCell>
+                <TableCell sx={headerStyle}>Property</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {
+                Object.keys(groupedTraits).map((key: string, index: number) => {
+                  return (
+                    <TableRow key={index}>
+                      <TableCell sx={cellStyle}>
+                        {key.charAt(0).toUpperCase() + key.slice(1)}
+                      </TableCell>
+                      <TableCell sx={cellStyle}>
+                        <RuleList specialRules={groupedTraits[key]} />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </>
+  );
+}

--- a/views/upgrades/Upgrades.tsx
+++ b/views/upgrades/Upgrades.tsx
@@ -14,6 +14,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../data/store";
 import UpgradeGroup from "./UpgradeGroup";
 import UnitEquipmentTable from "../UnitEquipmentTable";
+import CampaignTraitTable from "../CampaignTraitTable";
 import RuleList from "../components/RuleList";
 import { ISpecialRule, IUpgradePackage } from "../../data/interfaces";
 import UnitService from "../../services/UnitService";
@@ -211,6 +212,8 @@ export function Upgrades() {
             )}
             {/* Equipment */}
             <UnitEquipmentTable loadout={selectedUnit.loadout} square={true} />
+            {/* Campaign Traits */}
+            <CampaignTraitTable traits={selectedUnit.traits} square={true} />
             {isPsychic && <SpellsTable unit={selectedUnit} />}
             <UnitNotes selectedUnit={selectedUnit} />
           </Stack>


### PR DESCRIPTION
Added table view of campaign traits below equipment if at least one is selected.

This addresses the feature request in [issue 347](https://github.com/AdamLay/opr-army-forge/issues/347)