### PR TITLE
#345 AOFS command groups are removed when duplicating units

### DIFF
--- a/data/listSlice.ts
+++ b/data/listSlice.ts
@@ -122,6 +122,15 @@ export const listSlice = createSlice({
         }
       })
 
+      if (state.gameSystem === "aofs") {
+        unitsMapped.forEach((u, i) => {
+          u.selectedUpgrades = u.selectedUpgrades.filter((upgrade) =>
+            (upgrade.option.label != "Sergeant") &&
+            (upgrade.option.label != "Musician") &&
+            (upgrade.option.label != "Battle Standard"));
+          });
+      }
+
       //state.units.splice(index ?? -1, 0, ...unitsMapped)
       state.units.push(...unitsMapped);
       state.points = UpgradeService.calculateListTotal(state.units);


### PR DESCRIPTION
This avoids creating invalid armies with multiple Sergeants, Musicians or Battle Standards.

Fixes the remaining points of the linked issue.