### PR TITLE
#369 fixed by sorting Special Rules before displaying them in print view

### DIFF
--- a/views/components/SpecialRulesCard.tsx
+++ b/views/components/SpecialRulesCard.tsx
@@ -47,10 +47,13 @@ function SpecialRulesCard({ usedRules, spells, ruleDefinitions }: SpecialRulesCa
     }
   }
 
+  // sorting is required because the array is not necessarily in alphabetical order as we push the extra rules from Spells last
+  const sortedRuleDefs = _.orderBy(usedRuleDefs, x => x.name);
+
   return (
     <ViewCard title="Special Rules">
       <Box className={style.grid} sx={{ p: 2, mt: 1 }}>
-        {_.uniqBy(usedRuleDefs, (x) => x.name).map((r, i) => (
+        {_.uniqBy(sortedRuleDefs, (x) => x.name).map((r, i) => (
           <Typography key={i} sx={{ breakInside: "avoid" }}>
             <span style={{ fontWeight: 600 }}>{r.name + ": "}</span>
             <span>{r.description}</span>


### PR DESCRIPTION
fixed issue, now sorting is correct for the test case listed in [issue 369](https://github.com/AdamLay/opr-army-forge/issues/369)

![Special Rules Wizard Spells sort order fixed](https://user-images.githubusercontent.com/7880831/200543977-caa7b8ba-adfc-4b38-a27c-a0b8a8c21489.png)
